### PR TITLE
Single Executable Support and Update Confirmation

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  SOLUTION_FILE: 'ARESLauncher.sln' 
+  SOLUTION_FILE: 'ARESLauncher.slnx' 
 
 jobs:
   build-and-test:

--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,5 @@ $RECYCLE.BIN/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+.dotnet-cli

--- a/ARESLauncher.Tests/ARESLauncher.Tests.csproj
+++ b/ARESLauncher.Tests/ARESLauncher.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.7.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ARESLauncher\ARESLauncher.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>

--- a/ARESLauncher.Tests/AresUpdaterTests.cs
+++ b/ARESLauncher.Tests/AresUpdaterTests.cs
@@ -66,11 +66,54 @@ public class AresUpdaterTests
       Assert.That(metadata, Is.Not.Null);
       Assert.That(metadata!.Source, Is.EqualTo(source));
       Assert.That(metadata.Version, Is.EqualTo(version.ToNormalizedString()));
+      Assert.That(metadata.Layout, Is.EqualTo(AresReleaseLayout.UnifiedUiOnly));
+      Assert.That(configuration.Current.InstalledAresLayout, Is.EqualTo(AresReleaseLayout.UnifiedUiOnly));
 
       Assert.That(appSettingsUpdater.UpdateAllCallCount, Is.EqualTo(1));
       Assert.That(certificateManager.UpdateCallCount, Is.EqualTo(1));
       Assert.That(databaseManager.RefreshCallCount, Is.EqualTo(1));
       Assert.That(databaseManager.RunMigrationsCallCount, Is.EqualTo(0));
+    }
+    finally
+    {
+      TestPaths.DeleteDirectoryIfExists(tempRoot);
+    }
+  }
+
+  [Test]
+  public async Task Update_PersistsSplitLayout_WhenServiceExecutableExists()
+  {
+    var tempRoot = TestPaths.CreateTempDirectory();
+    var uiDir = Path.Combine(tempRoot, "ui");
+
+    try
+    {
+      var archivePath = TestArchives.CreateArchive(tempRoot, "combined.zip", ("UI", "ui"), ("AresService", "svc"));
+      var source = new AresSource("AFRL-ARES", "ARES");
+      var version = new SemanticVersion(2, 0, 0);
+      var downloader = new RecordingAresDownloader(archivePath);
+      var configuration = new FakeAppConfigurationService(new LauncherConfiguration
+      {
+        CurrentAresRepo = source,
+        UiBinaryPath = uiDir,
+        ServiceBinaryPath = uiDir
+      });
+
+      var updater = new AresUpdater(
+        downloader,
+        configuration,
+        new FakeAppSettingsUpdater(),
+        new FakeCertificateManager(),
+        new FakeDatabaseManager(),
+        new FakeAresBinaryManager(),
+        NullLogger<AresUpdater>.Instance);
+
+      await updater.Update(version);
+
+      var metadata = BinaryMetadataHelper.ReadMetadata(uiDir);
+      Assert.That(metadata, Is.Not.Null);
+      Assert.That(metadata!.Layout, Is.EqualTo(AresReleaseLayout.SplitUiAndService));
+      Assert.That(configuration.Current.InstalledAresLayout, Is.EqualTo(AresReleaseLayout.SplitUiAndService));
     }
     finally
     {

--- a/ARESLauncher.Tests/AresUpdaterTests.cs
+++ b/ARESLauncher.Tests/AresUpdaterTests.cs
@@ -1,0 +1,80 @@
+using System.IO;
+using System.Threading.Tasks;
+using ARESLauncher.Configuration;
+using ARESLauncher.Models;
+using ARESLauncher.Services;
+using ARESLauncher.Tools;
+using Microsoft.Extensions.Logging.Abstractions;
+using NuGet.Versioning;
+
+namespace ARESLauncher.Tests;
+
+[TestFixture]
+public class AresUpdaterTests
+{
+  [Test]
+  public async Task Update_DownloadsAndUnpacksSinglePackage()
+  {
+    var tempRoot = TestPaths.CreateTempDirectory();
+    var uiDir = Path.Combine(tempRoot, "ui");
+    var serviceDir = Path.Combine(tempRoot, "service");
+    Directory.CreateDirectory(uiDir);
+    Directory.CreateDirectory(serviceDir);
+    File.WriteAllText(Path.Combine(uiDir, "stale.txt"), "old");
+    File.WriteAllText(Path.Combine(serviceDir, "stale.txt"), "old");
+
+    try
+    {
+      var archivePath = TestArchives.CreateArchive(tempRoot, "combined.zip", ("app.bin", "payload"));
+      var source = new AresSource("AFRL-ARES", "ARES");
+      var version = new SemanticVersion(1, 2, 3);
+      var downloader = new RecordingAresDownloader(archivePath);
+      var configuration = new FakeAppConfigurationService(new LauncherConfiguration
+      {
+        CurrentAresRepo = source,
+        UiBinaryPath = uiDir,
+        ServiceBinaryPath = serviceDir,
+        GitToken = "token"
+      });
+      var appSettingsUpdater = new FakeAppSettingsUpdater();
+      var certificateManager = new FakeCertificateManager();
+      var databaseManager = new FakeDatabaseManager();
+      var binaryManager = new FakeAresBinaryManager();
+
+      var updater = new AresUpdater(
+        downloader,
+        configuration,
+        appSettingsUpdater,
+        certificateManager,
+        databaseManager,
+        binaryManager,
+        NullLogger<AresUpdater>.Instance);
+
+      await updater.Update(version);
+
+      Assert.That(downloader.DownloadCallCount, Is.EqualTo(1));
+      Assert.That(downloader.LastSource, Is.EqualTo(source));
+      Assert.That(downloader.LastVersion, Is.EqualTo(version));
+      Assert.That(downloader.LastDestination, Is.EqualTo(Path.GetTempPath()));
+      Assert.That(downloader.LastAuthToken, Is.EqualTo("token"));
+
+      Assert.That(File.Exists(Path.Combine(uiDir, "app.bin")), Is.True);
+      Assert.That(File.Exists(Path.Combine(uiDir, "stale.txt")), Is.False);
+      Assert.That(Directory.Exists(serviceDir), Is.False);
+
+      var metadata = BinaryMetadataHelper.ReadMetadata(uiDir);
+      Assert.That(metadata, Is.Not.Null);
+      Assert.That(metadata!.Source, Is.EqualTo(source));
+      Assert.That(metadata.Version, Is.EqualTo(version.ToNormalizedString()));
+
+      Assert.That(appSettingsUpdater.UpdateAllCallCount, Is.EqualTo(1));
+      Assert.That(certificateManager.UpdateCallCount, Is.EqualTo(1));
+      Assert.That(databaseManager.RefreshCallCount, Is.EqualTo(1));
+      Assert.That(databaseManager.RunMigrationsCallCount, Is.EqualTo(0));
+    }
+    finally
+    {
+      TestPaths.DeleteDirectoryIfExists(tempRoot);
+    }
+  }
+}

--- a/ARESLauncher.Tests/Configuration/LauncherConfigurationTests.cs
+++ b/ARESLauncher.Tests/Configuration/LauncherConfigurationTests.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using ARESLauncher.Configuration;
+using ARESLauncher.Models;
+
+namespace ARESLauncher.Tests.Configuration;
+
+[TestFixture]
+public class LauncherConfigurationTests
+{
+  [Test]
+  public void LauncherConfiguration_SerializesAndDeserializes_InstalledLayout()
+  {
+    var configuration = new LauncherConfiguration
+    {
+      InstalledAresLayout = AresReleaseLayout.UnifiedUiOnly
+    };
+
+    var json = JsonSerializer.Serialize(configuration);
+    var roundTripped = JsonSerializer.Deserialize<LauncherConfiguration>(json);
+
+    Assert.That(json, Does.Contain("UnifiedUiOnly"));
+    Assert.That(roundTripped, Is.Not.Null);
+    Assert.That(roundTripped!.InstalledAresLayout, Is.EqualTo(AresReleaseLayout.UnifiedUiOnly));
+  }
+}

--- a/ARESLauncher.Tests/LegacyRegression/LegacyBundleCompatibilityTests.cs
+++ b/ARESLauncher.Tests/LegacyRegression/LegacyBundleCompatibilityTests.cs
@@ -1,4 +1,5 @@
 using ARESLauncher.Configuration;
+using ARESLauncher.Models;
 using ARESLauncher.Tools;
 using System.Text.Json;
 
@@ -42,6 +43,7 @@ public class LegacyBundleCompatibilityTests
     Assert.That(configuration.AvailableAresRepos, Has.Length.EqualTo(2));
     Assert.That(configuration.AvailableAresRepos[1].Owner, Is.EqualTo("Example"));
     Assert.That(configuration.AvailableAresRepos[1].Repo, Is.EqualTo("Fork"));
+    Assert.That(configuration.InstalledAresLayout, Is.EqualTo(AresReleaseLayout.SplitUiAndService));
 
     var rewrittenJson = JsonSerializer.Serialize(configuration);
 
@@ -75,6 +77,7 @@ public class LegacyBundleCompatibilityTests
       Assert.That(metadata.Source!.Owner, Is.EqualTo("AFRL-ARES"));
       Assert.That(metadata.Source.Repo, Is.EqualTo("ARES"));
       Assert.That(metadata.Version, Is.EqualTo("1.2.3"));
+      Assert.That(metadata.Layout, Is.Null);
     }
     finally
     {

--- a/ARESLauncher.Tests/LegacyRegression/LegacyBundleCompatibilityTests.cs
+++ b/ARESLauncher.Tests/LegacyRegression/LegacyBundleCompatibilityTests.cs
@@ -1,0 +1,84 @@
+using ARESLauncher.Configuration;
+using ARESLauncher.Tools;
+using System.Text.Json;
+
+namespace ARESLauncher.Tests.LegacyRegression;
+
+[TestFixture]
+public class LegacyBundleCompatibilityTests
+{
+  // We used to have Bundle as an option in case we packaged UI and Service separately
+  // so if a user still has an older config file, we should handle that gracefully
+  [Test]
+  public void LauncherConfiguration_DeserializesLegacyBundleField_AndSerializesWithoutIt()
+  {
+    const string json = """
+                        {
+                          "CurrentAresRepo": {
+                            "Owner": "AFRL-ARES",
+                            "Repo": "ARES",
+                            "Bundle": false
+                          },
+                          "AvailableAresRepos": [
+                            {
+                              "Owner": "AFRL-ARES",
+                              "Repo": "ARES",
+                              "Bundle": true
+                            },
+                            {
+                              "Owner": "Example",
+                              "Repo": "Fork",
+                              "Bundle": false
+                            }
+                          ]
+                        }
+                        """;
+
+    var configuration = JsonSerializer.Deserialize<LauncherConfiguration>(json);
+
+    Assert.That(configuration, Is.Not.Null);
+    Assert.That(configuration!.CurrentAresRepo.Owner, Is.EqualTo("AFRL-ARES"));
+    Assert.That(configuration.CurrentAresRepo.Repo, Is.EqualTo("ARES"));
+    Assert.That(configuration.AvailableAresRepos, Has.Length.EqualTo(2));
+    Assert.That(configuration.AvailableAresRepos[1].Owner, Is.EqualTo("Example"));
+    Assert.That(configuration.AvailableAresRepos[1].Repo, Is.EqualTo("Fork"));
+
+    var rewrittenJson = JsonSerializer.Serialize(configuration);
+
+    Assert.That(rewrittenJson, Does.Not.Contain("\"Bundle\""));
+  }
+
+  [Test]
+  public void BinaryMetadataHelper_ReadMetadata_IgnoresLegacyBundleField()
+  {
+    var tempRoot = TestPaths.CreateTempDirectory();
+
+    try
+    {
+      var json = """
+                 {
+                   "Source": {
+                     "Owner": "AFRL-ARES",
+                     "Repo": "ARES",
+                     "Bundle": true
+                   },
+                   "Version": "1.2.3"
+                 }
+                 """;
+
+      File.WriteAllText(Path.Combine(tempRoot, BinaryMetadataHelper.MetadataFileName), json);
+
+      var metadata = BinaryMetadataHelper.ReadMetadata(tempRoot);
+
+      Assert.That(metadata, Is.Not.Null);
+      Assert.That(metadata!.Source, Is.Not.Null);
+      Assert.That(metadata.Source!.Owner, Is.EqualTo("AFRL-ARES"));
+      Assert.That(metadata.Source.Repo, Is.EqualTo("ARES"));
+      Assert.That(metadata.Version, Is.EqualTo("1.2.3"));
+    }
+    finally
+    {
+      TestPaths.DeleteDirectoryIfExists(tempRoot);
+    }
+  }
+}

--- a/ARESLauncher.Tests/TestSupport/TestArchives.cs
+++ b/ARESLauncher.Tests/TestSupport/TestArchives.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using System.IO.Compression;
+
+namespace ARESLauncher.Tests;
+
+internal static class TestArchives
+{
+  public static string CreateArchive(string root, string fileName, params (string Path, string Content)[] entries)
+  {
+    var archivePath = Path.Combine(root, fileName);
+
+    using var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create);
+    foreach(var (path, content) in entries)
+    {
+      var entry = archive.CreateEntry(path);
+      using var writer = new StreamWriter(entry.Open());
+      writer.Write(content);
+    }
+
+    return archivePath;
+  }
+}

--- a/ARESLauncher.Tests/TestSupport/TestDoubles.cs
+++ b/ARESLauncher.Tests/TestSupport/TestDoubles.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Threading.Tasks;
+using ARESLauncher.Configuration;
+using ARESLauncher.Models;
+using ARESLauncher.Models.AppSettings;
+using ARESLauncher.Services;
+using ARESLauncher.Services.Configuration;
+using NuGet.Versioning;
+
+namespace ARESLauncher.Tests;
+
+internal sealed class RecordingAresDownloader(string archivePath) : IAresDownloader
+{
+  public int DownloadCallCount { get; private set; }
+  public AresSource? LastSource { get; private set; }
+  public SemanticVersion? LastVersion { get; private set; }
+  public string? LastDestination { get; private set; }
+  public string? LastAuthToken { get; private set; }
+
+  public Task<SemanticVersion[]> GetAvailableVersions(AresSource source, string? authToken)
+  {
+    throw new NotSupportedException();
+  }
+
+  public Task<SemanticVersion[]> GetAvailableVersions(LauncherSource soruce)
+  {
+    throw new NotSupportedException();
+  }
+
+  public Task<string> Download(LauncherSource source, SemanticVersion version, string destination, string? authToken,
+    IProgress<double>? progress = null)
+  {
+    throw new NotSupportedException();
+  }
+
+  public Task<string> Download(AresSource source, SemanticVersion version, string destination, string? authToken,
+    IProgress<double>? progress = null)
+  {
+    DownloadCallCount++;
+    LastSource = source;
+    LastVersion = version;
+    LastDestination = destination;
+    LastAuthToken = authToken;
+    progress?.Report(1);
+    return Task.FromResult(archivePath);
+  }
+}
+
+internal sealed class FakeAppConfigurationService(LauncherConfiguration current) : IAppConfigurationService
+{
+  public LauncherConfiguration Current { get; private set; } = current;
+
+  public event EventHandler? ConfigUpdated;
+
+  public void Update(Action<LauncherConfiguration> applyChanges)
+  {
+    applyChanges(Current);
+    ConfigUpdated?.Invoke(this, EventArgs.Empty);
+  }
+}
+
+internal sealed class FakeAppSettingsUpdater : IAppSettingsUpdater
+{
+  public int UpdateAllCallCount { get; private set; }
+
+  public void Update(AresComponent component)
+  {
+  }
+
+  public void UpdateAll()
+  {
+    UpdateAllCallCount++;
+  }
+}
+
+internal sealed class FakeCertificateManager : ICertificateManager
+{
+  public int UpdateCallCount { get; private set; }
+
+  public Task Update()
+  {
+    UpdateCallCount++;
+    return Task.CompletedTask;
+  }
+}
+
+internal sealed class FakeDatabaseManager : IDatabaseManager
+{
+  public DatabaseStatus DatabaseStatus => DatabaseStatus.UpToDate;
+  public int RefreshCallCount { get; private set; }
+  public int RunMigrationsCallCount { get; private set; }
+
+  public Task RunMigrations()
+  {
+    RunMigrationsCallCount++;
+    return Task.CompletedTask;
+  }
+
+  public Task Refresh()
+  {
+    RefreshCallCount++;
+    return Task.CompletedTask;
+  }
+}
+
+internal sealed class FakeAresBinaryManager : IAresBinaryManager
+{
+  public SemanticVersion? CurrentVersion => null;
+  public AppSettingsService? ServiceSettings => null;
+  public AppSettingsUi? UiSettings => null;
+  public AresSource? CurrentSource => null;
+
+  public Task Refresh()
+  {
+    return Task.CompletedTask;
+  }
+
+  public void SetUiDataPath(Uri path)
+  {
+  }
+
+  public void SetServiceDataPath(Uri uri)
+  {
+  }
+}

--- a/ARESLauncher.Tests/TestSupport/TestDoubles.cs
+++ b/ARESLauncher.Tests/TestSupport/TestDoubles.cs
@@ -109,6 +109,7 @@ internal sealed class FakeAresBinaryManager : IAresBinaryManager
   public AppSettingsService? ServiceSettings => null;
   public AppSettingsUi? UiSettings => null;
   public AresSource? CurrentSource => null;
+  public AresReleaseLayout CurrentLayout { get; set; } = AresReleaseLayout.SplitUiAndService;
 
   public Task Refresh()
   {

--- a/ARESLauncher.Tests/TestSupport/TestPaths.cs
+++ b/ARESLauncher.Tests/TestSupport/TestPaths.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+
+namespace ARESLauncher.Tests;
+
+internal static class TestPaths
+{
+  public static string CreateTempDirectory()
+  {
+    var path = Path.Combine(Path.GetTempPath(), "ARESLauncher.Tests", Guid.NewGuid().ToString("N"));
+    Directory.CreateDirectory(path);
+    return path;
+  }
+
+  public static void DeleteDirectoryIfExists(string path)
+  {
+    if(Directory.Exists(path))
+      Directory.Delete(path, true);
+  }
+}

--- a/ARESLauncher.slnx
+++ b/ARESLauncher.slnx
@@ -1,4 +1,5 @@
 <Solution>
   <Project Path="ARESLauncher.Desktop/ARESLauncher.Desktop.csproj" />
+  <Project Path="ARESLauncher.Tests/ARESLauncher.Tests.csproj" Id="86bf7481-a430-4b5d-800d-f334c6e4eb0a" />
   <Project Path="ARESLauncher/ARESLauncher.csproj" />
 </Solution>

--- a/ARESLauncher/Configuration/LauncherConfiguration.cs
+++ b/ARESLauncher/Configuration/LauncherConfiguration.cs
@@ -37,6 +37,7 @@ public class LauncherConfiguration
   public string CertificatePath { get; } = Path.Combine(_appPath, "Data", "AresOS.pfx");
   public string CertificatePassword { get; } = "SecurePassword";
   public string GitToken { get; set; } = "";
+  public AresReleaseLayout InstalledAresLayout { get; set; } = AresReleaseLayout.SplitUiAndService;
 
   public string AresServiceProcessName { get; set; } = "AresService";
   public string AresUiProcessName { get; set; } = "UI";

--- a/ARESLauncher/Models/AresBinaryMetadata.cs
+++ b/ARESLauncher/Models/AresBinaryMetadata.cs
@@ -8,4 +8,6 @@ public class AresBinaryMetadata
   ///   SemanticVersion stored as normalized string to simplify serialization.
   /// </summary>
   public string? Version { get; set; }
+
+  public AresReleaseLayout? Layout { get; set; }
 }

--- a/ARESLauncher/Models/AresComponent.cs
+++ b/ARESLauncher/Models/AresComponent.cs
@@ -3,6 +3,5 @@ namespace ARESLauncher.Models;
 public enum AresComponent
 {
   Ui,
-  Service,
-  Both
+  Service
 }

--- a/ARESLauncher/Models/AresReleaseLayout.cs
+++ b/ARESLauncher/Models/AresReleaseLayout.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace ARESLauncher.Models;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum AresReleaseLayout
+{
+  SplitUiAndService,
+  UnifiedUiOnly
+}

--- a/ARESLauncher/Models/AresSource.cs
+++ b/ARESLauncher/Models/AresSource.cs
@@ -5,5 +5,4 @@ namespace ARESLauncher.Models;
 /// </summary>
 /// <param name="Owner">Owner of the repo</param>
 /// <param name="Repo">The repo name itself</param>
-/// <param name="Bundle">Whether the releases here contain both UI and Service in one package</param>
-public record AresSource(string Owner, string Repo, bool Bundle = true);
+public record AresSource(string Owner, string Repo);

--- a/ARESLauncher/Models/UpdateConfirmationRequest.cs
+++ b/ARESLauncher/Models/UpdateConfirmationRequest.cs
@@ -1,0 +1,9 @@
+using NuGet.Versioning;
+
+namespace ARESLauncher.Models;
+
+public class UpdateConfirmationRequest
+{
+  public required SemanticVersion CurrentVersion { get; init; }
+  public required SemanticVersion TargetVersion { get; init; }
+}

--- a/ARESLauncher/Services/AppSettingsUpdater.cs
+++ b/ARESLauncher/Services/AppSettingsUpdater.cs
@@ -13,6 +13,12 @@ public class AppSettingsUpdater(IAppConfigurationService _configurationService, 
 {
   public void Update(AresComponent component)
   {
+    if(component == AresComponent.Service &&
+       _configurationService.Current.InstalledAresLayout == AresReleaseLayout.UnifiedUiOnly)
+    {
+      return;
+    }
+
     switch(component)
     {
       case AresComponent.Ui:
@@ -28,7 +34,9 @@ public class AppSettingsUpdater(IAppConfigurationService _configurationService, 
 
   public void UpdateAll()
   {
-    AresComponent[] components = [AresComponent.Ui, AresComponent.Service];
+    AresComponent[] components = _configurationService.Current.InstalledAresLayout == AresReleaseLayout.UnifiedUiOnly
+      ? [AresComponent.Ui]
+      : [AresComponent.Ui, AresComponent.Service];
     foreach(var aresComponent in components)
       Update(aresComponent);
   }

--- a/ARESLauncher/Services/AresBinaryManager.cs
+++ b/ARESLauncher/Services/AresBinaryManager.cs
@@ -34,28 +34,31 @@ public class AresBinaryManager : IAresBinaryManager
   public AppSettingsService? ServiceSettings { get; private set; }
   public AppSettingsUi? UiSettings { get; private set; }
   public AresSource? CurrentSource { get; private set; }
+  public AresReleaseLayout CurrentLayout { get; private set; } = AresReleaseLayout.SplitUiAndService;
 
   public Task Refresh()
   {
+    var uiMetadata = BinaryMetadataHelper.ReadMetadata(_configurationService.Current.UiBinaryPath);
+    var serviceMetadata = BinaryMetadataHelper.ReadMetadata(_configurationService.Current.ServiceBinaryPath);
+    var metadata = uiMetadata ?? serviceMetadata;
+    CurrentLayout = ResolveLayout(uiMetadata, serviceMetadata);
+
     // Load appsettings (if present)
     UiSettings =
       TryLoadAppSettings<AppSettingsUi>(Path.Combine(_configurationService.Current.UiBinaryPath,
         "appsettings.ui.json"));
-    ServiceSettings =
-      TryLoadAppSettings<AppSettingsService>(Path.Combine(_configurationService.Current.ServiceBinaryPath,
-        "appsettings.aresservice.json"));
+    ServiceSettings = CurrentLayout == AresReleaseLayout.SplitUiAndService
+      ? TryLoadAppSettings<AppSettingsService>(Path.Combine(_configurationService.Current.ServiceBinaryPath,
+        "appsettings.aresservice.json"))
+      : null;
 
     if(_logger.IsEnabled(LogLevel.Debug))
     {
       if(UiSettings is null)
         _logger.LogDebug("Ui settings not found in {}", _configurationService.Current.UiBinaryPath);
-      if(ServiceSettings is null)
+      if(CurrentLayout == AresReleaseLayout.SplitUiAndService && ServiceSettings is null)
         _logger.LogDebug("Service settings not found in {}", _configurationService.Current.ServiceBinaryPath);
     }
-
-    var uiMetadata = BinaryMetadataHelper.ReadMetadata(_configurationService.Current.UiBinaryPath);
-    var serviceMetadata = BinaryMetadataHelper.ReadMetadata(_configurationService.Current.ServiceBinaryPath);
-    var metadata = uiMetadata ?? serviceMetadata;
 
     if(uiMetadata is not null && serviceMetadata is not null)
     {
@@ -93,6 +96,43 @@ public class AresBinaryManager : IAresBinaryManager
   {
     var newPath = ToLocalPath(uri);
     _configurationService.Update(cfg => cfg.ServiceBinaryPath = newPath);
+  }
+
+  private AresReleaseLayout ResolveLayout(AresBinaryMetadata? uiMetadata, AresBinaryMetadata? serviceMetadata)
+  {
+    var metadataLayout = uiMetadata?.Layout ?? serviceMetadata?.Layout;
+    if(metadataLayout is not null)
+    {
+      return metadataLayout.Value;
+    }
+
+    var uiExecutable = _executableGetter.GetUiExecutablePath();
+    var serviceExecutable = GetServiceExecutablePathIgnoringLayout();
+    var uiExists = !string.IsNullOrWhiteSpace(uiExecutable) && File.Exists(uiExecutable);
+    var serviceExists = !string.IsNullOrWhiteSpace(serviceExecutable) && File.Exists(serviceExecutable);
+    if(uiExists && !serviceExists)
+    {
+      return AresReleaseLayout.UnifiedUiOnly;
+    }
+
+    return _configurationService.Current.InstalledAresLayout;
+  }
+
+  private string? GetServiceExecutablePathIgnoringLayout()
+  {
+    var servicePath = _configurationService.Current.ServiceBinaryPath;
+    if(string.IsNullOrWhiteSpace(servicePath))
+    {
+      return null;
+    }
+
+    var executablePath = Path.Combine(servicePath, "AresService");
+    if(System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+    {
+      executablePath = Path.ChangeExtension(executablePath, "exe");
+    }
+
+    return executablePath;
   }
 
   private SemanticVersion? TryGetInstalledVersion()

--- a/ARESLauncher/Services/AresGithubDownloader.cs
+++ b/ARESLauncher/Services/AresGithubDownloader.cs
@@ -79,21 +79,21 @@ public partial class AresGithubDownloader(ILogger<AresGithubDownloader> _logger)
     return versions;
   }
 
-  public async Task<string> Download(AresSource source, SemanticVersion version, AresComponent component,
+  public async Task<string> Download(AresSource source, SemanticVersion version,
     string destination, string? authToken, IProgress<double>? progress = null)
   {
     var client = CreateClient(authToken);
     var release = await GetReleaseForVersion(client, source, version);
-    var asset = SelectAssetForComponent(release, component) ??
+    var asset = SelectAssetForAresRelease(release) ??
                 throw new InvalidOperationException(
-                  $"No asset found in release {release.TagName} for component {component}.");
+                  $"No ARES asset found in release {release.TagName} for {OsBundleNameGetter.GetName()}.");
 
     var downloadUri = new Uri(asset.Url);
     var downloadResult = await Downloader.Download(downloadUri, destination, authToken, progress);
 
     // Technically ResultingFilePath could be null, but if our download result is a success, there's no reason it should.
     return !downloadResult.Success
-      ? throw new InvalidOperationException($"Failed to download {component} {version}: {downloadResult.Error}")
+      ? throw new InvalidOperationException($"Failed to download ARES {version}: {downloadResult.Error}")
       : downloadResult.ResultingFilePath!;
   }
 
@@ -143,28 +143,33 @@ public partial class AresGithubDownloader(ILogger<AresGithubDownloader> _logger)
     throw new InvalidOperationException($"Could not locate launcher release for version {version}.");
   }
 
-  private static ReleaseAsset? SelectAssetForComponent(Release release, AresComponent component)
+  private static ReleaseAsset? SelectAssetForAresRelease(Release release)
   {
     if(release.Assets is null || release.Assets.Count == 0)
       return null;
 
     var os = OsBundleNameGetter.GetName();
+    var candidateAssets = release.Assets
+      .Where(a => a.Name?.Contains(os, StringComparison.OrdinalIgnoreCase) is true)
+      .ToArray();
 
-    var keywords = component switch
-    {
-      AresComponent.Ui => ["ui", os],
-      AresComponent.Service => ["service", os],
-      AresComponent.Both => [os],
-      _ => Array.Empty<string>()
-    };
+    if(candidateAssets.Length == 0)
+      candidateAssets = release.Assets.ToArray();
 
-    var asset = release.Assets.FirstOrDefault(a =>
-      keywords.All(keyword => a.Name?.Contains(keyword, StringComparison.OrdinalIgnoreCase) == true));
+    var preferred = candidateAssets.FirstOrDefault(a =>
+      a.Name?.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) is true &&
+      !a.Name!.Contains("offline", StringComparison.OrdinalIgnoreCase));
 
-    if(asset is not null)
-      return asset;
+    if(preferred is not null)
+      return preferred;
 
-    return release.Assets.Count == 1 ? release.Assets[0] : null;
+    preferred = candidateAssets.FirstOrDefault(a =>
+      a.Name?.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) is true);
+
+    if(preferred is not null)
+      return preferred;
+
+    return candidateAssets.Length == 1 ? candidateAssets[0] : null;
   }
 
   private static ReleaseAsset? SelectAssetForLauncher(Release release)
@@ -174,21 +179,21 @@ public partial class AresGithubDownloader(ILogger<AresGithubDownloader> _logger)
 
     var os = OsBundleNameGetter.GetName();
     var candidateAssets = release.Assets
-      .Where(a => a.Name?.Contains(os, StringComparison.OrdinalIgnoreCase) == true)
+      .Where(a => a.Name?.Contains(os, StringComparison.OrdinalIgnoreCase) is true)
       .ToArray();
 
     if(candidateAssets.Length == 0)
       candidateAssets = release.Assets.ToArray();
 
     var preferred = candidateAssets.FirstOrDefault(a =>
-      a.Name?.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) == true &&
+      a.Name?.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) is true &&
       !a.Name!.Contains("offline", StringComparison.OrdinalIgnoreCase));
 
     if(preferred is not null)
       return preferred;
 
     preferred = candidateAssets.FirstOrDefault(a =>
-      a.Name?.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) == true);
+      a.Name?.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) is true);
 
     if(preferred is not null)
       return preferred;

--- a/ARESLauncher/Services/AresStarter.cs
+++ b/ARESLauncher/Services/AresStarter.cs
@@ -5,6 +5,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
+using ARESLauncher.Models;
 using CliWrap;
 using CliWrap.Exceptions;
 using Microsoft.Extensions.Logging;
@@ -13,6 +14,7 @@ namespace ARESLauncher.Services;
 
 public class AresStarter : IAresStarter
 {
+  private readonly IAresBinaryManager _aresBinaryManager;
   private readonly IExecutableGetter _executableGetter;
   private readonly ILogger<AresStarter> _logger;
   private readonly BehaviorSubject<bool> _aresUiRunningSubject = new(false);
@@ -24,8 +26,9 @@ public class AresStarter : IAresStarter
   private CancellationTokenSource _cancellationTokenSource = new();
   private int _stopInitiated = 0;
 
-  public AresStarter(IExecutableGetter executableGetter, ILogger<AresStarter> logger)
+  public AresStarter(IAresBinaryManager aresBinaryManager, IExecutableGetter executableGetter, ILogger<AresStarter> logger)
   {
+    _aresBinaryManager = aresBinaryManager;
     _executableGetter = executableGetter;
     _logger = logger;
     AresUiRunning = _aresUiRunningSubject.AsObservable();
@@ -37,7 +40,7 @@ public class AresStarter : IAresStarter
 
   public void Start()
   {
-    if(_aresUiRunningSubject.Value && _aresServiceRunningSubject.Value)
+    if(IsHealthyRunning())
     {
       _logger.LogDebug("Start requested while ARES is already running. Skipping.");
       return;
@@ -55,7 +58,7 @@ public class AresStarter : IAresStarter
       }
     }
 
-    if(!_aresServiceRunningSubject.Value)
+    if(_aresBinaryManager.CurrentLayout == AresReleaseLayout.SplitUiAndService && !_aresServiceRunningSubject.Value)
     {
       var serviceTask = StartService(_cancellationTokenSource.Token);
       if(serviceTask is null)
@@ -213,5 +216,12 @@ public class AresStarter : IAresStarter
     {
       _ = Stop();
     }
+  }
+
+  private bool IsHealthyRunning()
+  {
+    return _aresBinaryManager.CurrentLayout == AresReleaseLayout.UnifiedUiOnly
+      ? _aresUiRunningSubject.Value
+      : _aresUiRunningSubject.Value && _aresServiceRunningSubject.Value;
   }
 }

--- a/ARESLauncher/Services/AresUpdater.cs
+++ b/ARESLauncher/Services/AresUpdater.cs
@@ -59,7 +59,9 @@ public class AresUpdater : IAresUpdater
     var version = Tools.VersionExtensions.GetVersionFromZipName(path);  
 
     await Unpacker.Unpack(path, dest);
-    BinaryMetadataHelper.WriteMetadata(dest, source, version);
+    var layout = DetectInstalledLayout(dest);
+    _configurationService.Update(cfg => cfg.InstalledAresLayout = layout);
+    BinaryMetadataHelper.WriteMetadata(dest, source, version, layout);
 
     await ApplyLocalSettings();
   }
@@ -81,7 +83,8 @@ public class AresUpdater : IAresUpdater
     _currentUpdateStepSubject.OnNext(UpdateStep.Downloading);
     try
     {
-      await DownloadPackage(source, version, uiDir);
+      var layout = await DownloadPackage(source, version, uiDir);
+      _configurationService.Update(cfg => cfg.InstalledAresLayout = layout);
     }
     catch(Exception)
     {
@@ -159,7 +162,7 @@ public class AresUpdater : IAresUpdater
   public IObservable<double> UpdateProgress { get; }
   public IObservable<UpdateStep> CurrentUpdateStep { get; }
 
-  private async Task DownloadPackage(AresSource source, SemanticVersion version, string dest)
+  private async Task<AresReleaseLayout> DownloadPackage(AresSource source, SemanticVersion version, string dest)
   {
     var tempPath = Path.GetTempPath();
     try
@@ -169,12 +172,27 @@ public class AresUpdater : IAresUpdater
         new Progress<double>(pg => _updateProgressSubject.OnNext(pg)));
       _updateStepDescriptionSubject.OnNext("Unpacking the package");
       await Unpacker.Unpack(packageDest, dest);
-      BinaryMetadataHelper.WriteMetadata(dest, source, version);
+      var layout = DetectInstalledLayout(dest);
+      BinaryMetadataHelper.WriteMetadata(dest, source, version, layout);
+      return layout;
     }
     catch(Exception e)
     {
       _logger.LogError("Failed to acquire the ARES package. {}", e);
       throw;
     }
+  }
+
+  private static AresReleaseLayout DetectInstalledLayout(string installDirectory)
+  {
+    var serviceExecutable = Path.Combine(installDirectory, "AresService");
+    if(OperatingSystem.IsWindows())
+    {
+      serviceExecutable = Path.ChangeExtension(serviceExecutable, "exe");
+    }
+
+    return File.Exists(serviceExecutable)
+      ? AresReleaseLayout.SplitUiAndService
+      : AresReleaseLayout.UnifiedUiOnly;
   }
 }

--- a/ARESLauncher/Services/AresUpdater.cs
+++ b/ARESLauncher/Services/AresUpdater.cs
@@ -53,7 +53,7 @@ public class AresUpdater : IAresUpdater
 
   public async Task InstallOffline(string path)
   {
-    _updateStepDescriptionSubject.OnNext("Unpacking the bundle");
+    _updateStepDescriptionSubject.OnNext("Unpacking the package");
     var dest = _configurationService.Current.UiBinaryPath;
     var source = _configurationService.Current.CurrentAresRepo;
     var version = Tools.VersionExtensions.GetVersionFromZipName(path);  
@@ -81,10 +81,7 @@ public class AresUpdater : IAresUpdater
     _currentUpdateStepSubject.OnNext(UpdateStep.Downloading);
     try
     {
-      if(source.Bundle)
-        await DownloadBundle(source, version, uiDir);
-      else
-        await DownloadIndividualComponents(source, version, uiDir, serviceDir);
+      await DownloadPackage(source, version, uiDir);
     }
     catch(Exception)
     {
@@ -118,7 +115,7 @@ public class AresUpdater : IAresUpdater
     //No ARES installed, check for offline package
     if(_binaryManager.CurrentVersion is null)
     {
-      _updateStepDescriptionSubject.OnNext("Checking for offline bundle.");
+      _updateStepDescriptionSubject.OnNext("Checking for offline package.");
       _currentUpdateStepSubject.OnNext(UpdateStep.Other);
       var offlinePath = Path.Combine(AppContext.BaseDirectory, "Offline");
       if(Directory.Exists(offlinePath))
@@ -162,57 +159,21 @@ public class AresUpdater : IAresUpdater
   public IObservable<double> UpdateProgress { get; }
   public IObservable<UpdateStep> CurrentUpdateStep { get; }
 
-  private async Task DownloadBundle(AresSource source, SemanticVersion version, string dest)
+  private async Task DownloadPackage(AresSource source, SemanticVersion version, string dest)
   {
     var tempPath = Path.GetTempPath();
     try
     {
-      _updateStepDescriptionSubject.OnNext("Downloading the bundle.");
-      var bundleDest = await _downloader.Download(source, version, AresComponent.Both, tempPath, _configurationService.Current.GitToken,
+      _updateStepDescriptionSubject.OnNext("Downloading the package.");
+      var packageDest = await _downloader.Download(source, version, tempPath, _configurationService.Current.GitToken,
         new Progress<double>(pg => _updateProgressSubject.OnNext(pg)));
-      _updateStepDescriptionSubject.OnNext("Unpacking the bundle");
-      await Unpacker.Unpack(bundleDest, dest);
+      _updateStepDescriptionSubject.OnNext("Unpacking the package");
+      await Unpacker.Unpack(packageDest, dest);
       BinaryMetadataHelper.WriteMetadata(dest, source, version);
     }
     catch(Exception e)
     {
-      _logger.LogError("Failed to acquire the combined bundle. {}", e);
-      throw;
-    }
-  }
-
-  private async Task DownloadIndividualComponents(AresSource source, SemanticVersion version, string uiDir,
-    string serviceDir)
-  {
-    var tempPath = Path.GetTempPath();
-    try
-    {
-      _updateStepDescriptionSubject.OnNext("Downloading the UI.");
-      var uiDest = await _downloader.Download(source, version, AresComponent.Ui, tempPath, _configurationService.Current.GitToken,
-        new Progress<double>(pg => _updateProgressSubject.OnNext(pg / 2)));
-      _updateStepDescriptionSubject.OnNext("Unpacking the UI");
-      await Unpacker.Unpack(uiDest, uiDir);
-      BinaryMetadataHelper.WriteMetadata(uiDir, source, version);
-    }
-    catch(Exception e)
-    {
-      _logger.LogError("Failed to acquire the UI. {}", e);
-      throw;
-    }
-
-    try
-    {
-      _updateStepDescriptionSubject.OnNext("Acquiring the Service.");
-      var serviceDest = await _downloader.Download(source, version, AresComponent.Service, tempPath, _configurationService.Current.GitToken,
-        new Progress<double>(pg => _updateProgressSubject.OnNext(.5 + pg / 2)));
-
-      _updateStepDescriptionSubject.OnNext("Unpacking the Service.");
-      await Unpacker.Unpack(serviceDest, serviceDir);
-      BinaryMetadataHelper.WriteMetadata(serviceDir, source, version);
-    }
-    catch(Exception e)
-    {
-      _logger.LogError("Failed to acquire the Service. {}", e);
+      _logger.LogError("Failed to acquire the ARES package. {}", e);
       throw;
     }
   }

--- a/ARESLauncher/Services/ConflictManager.cs
+++ b/ARESLauncher/Services/ConflictManager.cs
@@ -1,15 +1,19 @@
 ﻿using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using ARESLauncher.Models;
 using ARESLauncher.Services.Configuration;
 
 namespace ARESLauncher.Services;
 
-public class ConflictManager(IAresStarter _aresStarter, IAppConfigurationService _configurationService) : IConflictManager
+public class ConflictManager(IAresStarter _aresStarter, IAppConfigurationService _configurationService, IAresBinaryManager _aresBinaryManager) : IConflictManager
 {
 
   public bool FindPotentialService()
   {
+    if(_aresBinaryManager.CurrentLayout == AresReleaseLayout.UnifiedUiOnly)
+      return false;
+
     var process = GetServiceProcess();
     return process is not null; ;
   }
@@ -23,7 +27,9 @@ public class ConflictManager(IAresStarter _aresStarter, IAppConfigurationService
   public async Task Kill()
   {
     var uiProcess = GetUiProcess();
-    var serviceProcess = GetServiceProcess();
+    var serviceProcess = _aresBinaryManager.CurrentLayout == AresReleaseLayout.SplitUiAndService
+      ? GetServiceProcess()
+      : null;
     if(uiProcess is not null)
     {
       uiProcess.Kill();
@@ -39,6 +45,9 @@ public class ConflictManager(IAresStarter _aresStarter, IAppConfigurationService
 
   public void TakeOverService()
   {
+    if(_aresBinaryManager.CurrentLayout == AresReleaseLayout.UnifiedUiOnly)
+      return;
+
     var process = GetServiceProcess();
     if(process is null)
       return;

--- a/ARESLauncher/Services/DatabaseManager.cs
+++ b/ARESLauncher/Services/DatabaseManager.cs
@@ -2,24 +2,25 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using ARESLauncher.Models;
+using ARESLauncher.Services.Configuration;
 using ARESLauncher.Tools;
 using CliWrap;
 
 namespace ARESLauncher.Services;
 
-public class DatabaseManager(IExecutableGetter _executableGetter) : IDatabaseManager
+public class DatabaseManager(IExecutableGetter _executableGetter, IAppConfigurationService _configurationService) : IDatabaseManager
 {
   public DatabaseStatus DatabaseStatus { get; private set; } = DatabaseStatus.NonExistent;
   public async Task RunMigrations()
   {
-    var serviceExe = _executableGetter.GetServiceExecutablePath();
-    if (serviceExe is null)
+    var executable = GetDatabaseExecutablePath();
+    if (executable is null)
     {
       return;
     }
 
-    var workingDir = GetWorkingDir(serviceExe);
-    await Cli.Wrap(serviceExe)
+    var workingDir = GetWorkingDir(executable);
+    await Cli.Wrap(executable)
       .WithArguments(["--migrate"])
       .WithWorkingDirectory(workingDir)
       .ExecuteAsync();
@@ -29,20 +30,27 @@ public class DatabaseManager(IExecutableGetter _executableGetter) : IDatabaseMan
 
   public async Task Refresh()
   {
-    var serviceExe = _executableGetter.GetServiceExecutablePath();
-    if (serviceExe is null)
+    var executable = GetDatabaseExecutablePath();
+    if (executable is null)
     {
       return;
     }
 
-    var workingDir = GetWorkingDir(serviceExe);
-    var checkResult = await Cli.Wrap(serviceExe)
+    var workingDir = GetWorkingDir(executable);
+    var checkResult = await Cli.Wrap(executable)
       .WithArguments(["--check-database"])
       .WithValidation(CommandResultValidation.None)
       .WithWorkingDirectory(workingDir)
       .ExecuteAsync();
     
     DatabaseStatus = ExitCodeToDbStatus.GetDatabaseStatus(checkResult.ExitCode);
+  }
+
+  private string? GetDatabaseExecutablePath()
+  {
+    return _configurationService.Current.InstalledAresLayout == AresReleaseLayout.UnifiedUiOnly
+      ? _executableGetter.GetUiExecutablePath()
+      : _executableGetter.GetServiceExecutablePath();
   }
 
   private static string GetWorkingDir(string path)

--- a/ARESLauncher/Services/ExecutableGetter.cs
+++ b/ARESLauncher/Services/ExecutableGetter.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Runtime.InteropServices;
+using ARESLauncher.Models;
 using ARESLauncher.Services.Configuration;
 
 namespace ARESLauncher.Services;
@@ -13,6 +14,11 @@ public class ExecutableGetter(IAppConfigurationService _configurationService) : 
 
   public string? GetServiceExecutablePath()
   {
+    if(_configurationService.Current.InstalledAresLayout == AresReleaseLayout.UnifiedUiOnly)
+    {
+      return null;
+    }
+
     return GetPath(_configurationService.Current.ServiceBinaryPath, "AresService");
   }
 

--- a/ARESLauncher/Services/IAresBinaryManager.cs
+++ b/ARESLauncher/Services/IAresBinaryManager.cs
@@ -34,6 +34,11 @@ public interface IAresBinaryManager
   AresSource? CurrentSource { get; }
 
   /// <summary>
+  ///   The effective installed ARES release layout.
+  /// </summary>
+  AresReleaseLayout CurrentLayout { get; }
+
+  /// <summary>
   ///   Refreshes its knowledge about the current and available versions of ARES.
   /// </summary>
   /// <returns></returns>

--- a/ARESLauncher/Services/IAresDownloader.cs
+++ b/ARESLauncher/Services/IAresDownloader.cs
@@ -20,13 +20,8 @@ public interface IAresDownloader
     IProgress<double>? progress = null);
 
   /// <summary>
+  ///   Downloads the combined ARES release package for the requested version.
   /// </summary>
-  /// <param name="source"></param>
-  /// <param name="version"></param>
-  /// <param name="component"></param>
-  /// <param name="destination"></param>
-  /// <param name="progress"></param>
-  /// <returns>The file path of the newly downloaded item</returns>
-  Task<string> Download(AresSource source, SemanticVersion version, AresComponent component, string destination, string? authToken,
+  Task<string> Download(AresSource source, SemanticVersion version, string destination, string? authToken,
     IProgress<double>? progress = null);
 }

--- a/ARESLauncher/Tools/BinaryMetadataHelper.cs
+++ b/ARESLauncher/Tools/BinaryMetadataHelper.cs
@@ -15,7 +15,7 @@ public static class BinaryMetadataHelper
     WriteIndented = true
   };
 
-  public static void WriteMetadata(string directory, AresSource source, SemanticVersion version)
+  public static void WriteMetadata(string directory, AresSource source, SemanticVersion version, AresReleaseLayout layout)
   {
     if (string.IsNullOrWhiteSpace(directory)) return;
 
@@ -23,7 +23,8 @@ public static class BinaryMetadataHelper
     var metadata = new AresBinaryMetadata
     {
       Source = source,
-      Version = version.ToNormalizedString()
+      Version = version.ToNormalizedString(),
+      Layout = layout
     };
 
     try

--- a/ARESLauncher/ViewModels/AresSourceEditorViewModel.cs
+++ b/ARESLauncher/ViewModels/AresSourceEditorViewModel.cs
@@ -5,11 +5,10 @@ namespace ARESLauncher.ViewModels;
 
 public partial class AresSourceEditorViewModel : ViewModelBase
 {
-  public AresSourceEditorViewModel(string owner, string repo, bool bundle = true)
+  public AresSourceEditorViewModel(string owner, string repo)
   {
     Owner = owner;
     Repo = repo;
-    Bundle = bundle;
   }
 
   [Reactive]
@@ -18,11 +17,8 @@ public partial class AresSourceEditorViewModel : ViewModelBase
   [Reactive]
   public partial string Repo { get; set; }
 
-  [Reactive]
-  public partial bool Bundle { get; set; }
-
   public AresSource ToAresSource()
   {
-    return new AresSource(Owner, Repo, Bundle);
+    return new AresSource(Owner, Repo);
   }
 }

--- a/ARESLauncher/ViewModels/ConfigurationEditorViewModel.cs
+++ b/ARESLauncher/ViewModels/ConfigurationEditorViewModel.cs
@@ -17,12 +17,14 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
   private readonly IAppConfigurationService _configurationService;
   private readonly IAppSettingsUpdater _appSettingsUpdater;
   private readonly IReadOnlyList<DatabaseProvider> _databaseProviders;
+  private readonly IReadOnlyList<AresReleaseLayout> _releaseLayouts;
 
   public ConfigurationEditorViewModel(IAppConfigurationService configurationService, IAppSettingsUpdater appSettingsUpdater)
   {
     _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
     _appSettingsUpdater = appSettingsUpdater;
     _databaseProviders = Enum.GetValues<DatabaseProvider>();
+    _releaseLayouts = Enum.GetValues<AresReleaseLayout>();
 
     AvailableRepositories = new ObservableCollection<AresSourceEditorViewModel>();
     EditableUiBinaryPath = string.Empty;
@@ -36,6 +38,7 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
     EditableAresDataPath = string.Empty;
     EditableAresServiceProcessName = string.Empty;
     EditableAresUiProcessName = string.Empty;
+    EditableInstalledAresLayout = AresReleaseLayout.SplitUiAndService;
     LoadEditableConfiguration();
 
     AddRepositoryCommand = ReactiveCommand.Create(AddRepository);
@@ -48,6 +51,7 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
   public event EventHandler? ConfigurationSaved;
 
   public IReadOnlyList<DatabaseProvider> DatabaseProviders => _databaseProviders;
+  public IReadOnlyList<AresReleaseLayout> ReleaseLayouts => _releaseLayouts;
 
   public ObservableCollection<AresSourceEditorViewModel> AvailableRepositories { get; }
 
@@ -92,6 +96,9 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
 
   [Reactive]
   public partial string EditableAresUiProcessName { get; set; }
+
+  [Reactive]
+  public partial AresReleaseLayout EditableInstalledAresLayout { get; set; }
 
   [Reactive]
   public partial bool ShowAdvancedOptions { get; set; }
@@ -157,6 +164,7 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
       configuration.AresDataPath = EditableAresDataPath;
       configuration.AresServiceProcessName = EditableAresServiceProcessName;
       configuration.AresUiProcessName = EditableAresUiProcessName;
+      configuration.InstalledAresLayout = EditableInstalledAresLayout;
 
       var validRepositories = AvailableRepositories
         .Where(IsValidRepository)
@@ -204,6 +212,7 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
     EditableAresDataPath = current.AresDataPath;
     EditableAresServiceProcessName = current.AresServiceProcessName;
     EditableAresUiProcessName = current.AresUiProcessName;
+    EditableInstalledAresLayout = current.InstalledAresLayout;
 
     AvailableRepositories.Clear();
     foreach(var repo in current.AvailableAresRepos)

--- a/ARESLauncher/ViewModels/ConfigurationEditorViewModel.cs
+++ b/ARESLauncher/ViewModels/ConfigurationEditorViewModel.cs
@@ -208,7 +208,7 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
     AvailableRepositories.Clear();
     foreach(var repo in current.AvailableAresRepos)
     {
-      AvailableRepositories.Add(new AresSourceEditorViewModel(repo.Owner, repo.Repo, repo.Bundle));
+      AvailableRepositories.Add(new AresSourceEditorViewModel(repo.Owner, repo.Repo));
     }
 
     SelectedAvailableRepository = AvailableRepositories.FirstOrDefault();

--- a/ARESLauncher/ViewModels/ConfigurationOverviewViewModel.cs
+++ b/ARESLauncher/ViewModels/ConfigurationOverviewViewModel.cs
@@ -21,6 +21,7 @@ public partial class ConfigurationOverviewViewModel : ViewModelBase
   public ConfigurationOverviewViewModel(IAppConfigurationService configurationService)
   {
     _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
+    InstalledAresLayout = string.Empty;
     AresDataPath = "";
     Refresh();
   }

--- a/ARESLauncher/ViewModels/ConfigurationOverviewViewModel.cs
+++ b/ARESLauncher/ViewModels/ConfigurationOverviewViewModel.cs
@@ -68,6 +68,9 @@ public partial class ConfigurationOverviewViewModel : ViewModelBase
   }
 
   [Reactive]
+  public partial string InstalledAresLayout { get; private set; }
+
+  [Reactive]
   public partial string AresDataPath { get; private set; }
 
   public void Refresh()
@@ -82,5 +85,6 @@ public partial class ConfigurationOverviewViewModel : ViewModelBase
     AvailableRepositoriesDisplay = current.AvailableAresRepos.Select(repo => $"{repo.Owner}/{repo.Repo}").ToArray();
     GitToken = current.GitToken;
     AresDataPath = current.AresDataPath;
+    InstalledAresLayout = current.InstalledAresLayout.ToString();
   }
 }

--- a/ARESLauncher/ViewModels/MainViewModel.cs
+++ b/ARESLauncher/ViewModels/MainViewModel.cs
@@ -136,11 +136,15 @@ public partial class MainViewModel : ViewModelBase
           return AresState.Updating;
         }
 
-        if(isRunning == 1)
+        var layout = _aresBinaryManager.CurrentLayout;
+        var fullyRunning = layout == AresReleaseLayout.UnifiedUiOnly ? isRunning >= 1 : isRunning == 2;
+        var partiallyRunning = layout == AresReleaseLayout.SplitUiAndService && isRunning == 1;
+
+        if(partiallyRunning)
         {
           return AresState.OneRunning;
         }
-        if(isRunning == 2)
+        if(fullyRunning)
         {
           return AresState.BothRunning;
         }

--- a/ARESLauncher/ViewModels/MainViewModel.cs
+++ b/ARESLauncher/ViewModels/MainViewModel.cs
@@ -81,6 +81,7 @@ public partial class MainViewModel : ViewModelBase
     UpdateAresCommand = ReactiveCommand.CreateFromTask(UpdateAres);
     OpenBrowserCommand = ReactiveCommand.Create(browserOpener.Open);
     OpenLauncherReleasePageCommand = ReactiveCommand.CreateFromTask(CheckForUpdatedLauncher);
+    UpdateConfirmationDialog = new Interaction<UpdateConfirmationRequest, bool>();
     ConflictDialog = new Interaction<Unit, Unit>();
     ResolveConflictsCommand = ReactiveCommand.CreateFromTask(async () =>
     {
@@ -357,6 +358,7 @@ public partial class MainViewModel : ViewModelBase
   public ReactiveCommand<Unit, Unit> CheckForUpdate { get; }
 
   public Interaction<Unit, Unit> ConflictDialog { get; }
+  public Interaction<UpdateConfirmationRequest, bool> UpdateConfirmationDialog { get; }
   public bool ShowProgressBar => _showProgressBar.Value;
 
   public ConflictResolutionDialogViewModel GetConflictResolutionDialogViewModel()
@@ -394,6 +396,22 @@ public partial class MainViewModel : ViewModelBase
 
   private async Task UpdateAres()
   {
+    var currentVersion = _aresBinaryManager.CurrentVersion;
+    var targetVersion = AvailableVersions?.OrderDescending().FirstOrDefault();
+    if(RequiresUpdateConfirmation(currentVersion, targetVersion))
+    {
+      var shouldProceed = await UpdateConfirmationDialog.Handle(new UpdateConfirmationRequest
+      {
+        CurrentVersion = currentVersion!,
+        TargetVersion = targetVersion!
+      });
+
+      if(!shouldProceed)
+      {
+        return;
+      }
+    }
+
     try
     {
       Error = "";
@@ -461,5 +479,22 @@ public partial class MainViewModel : ViewModelBase
   {
     Overview.Refresh();
     _ = CheckAresCondition();
+  }
+  
+  // Check if we should ask for confirmation. We should ask if there's a major/minor update
+  // Let's ignore patches as those should not break things... should
+  private static bool RequiresUpdateConfirmation(SemanticVersion? currentVersion, SemanticVersion? targetVersion)
+  {
+    if(currentVersion is null || targetVersion is null)
+    {
+      return false;
+    }
+
+    if(targetVersion.Major > currentVersion.Major)
+    {
+      return true;
+    }
+
+    return targetVersion.Major == currentVersion.Major && targetVersion.Minor > currentVersion.Minor;
   }
 }

--- a/ARESLauncher/ViewModels/MainViewModel.cs
+++ b/ARESLauncher/ViewModels/MainViewModel.cs
@@ -67,6 +67,7 @@ public partial class MainViewModel : ViewModelBase
     _conflictManager = conflictManager;
     _isMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
     InstalledAresVersion = string.Empty;
+    AvailableAresUpdateVersion = string.Empty;
     Editor.ConfigurationSaved += OnConfigurationSaved;
 
     UpdateDatabaseCommand = ReactiveCommand.CreateFromTask(UpdateDb);
@@ -309,6 +310,9 @@ public partial class MainViewModel : ViewModelBase
   [Reactive]
   public partial string InstalledAresVersion { get; private set; }
 
+  [Reactive]
+  public partial string AvailableAresUpdateVersion { get; private set; }
+
   public string AresStateDescription => _aresStateDescription.Value;
 
   public int AresComponentsRunning => _aresComponentsRunning.Value;
@@ -324,6 +328,7 @@ public partial class MainViewModel : ViewModelBase
     await _aresBinaryManager.Refresh();
     InstalledAresVersion = _aresBinaryManager.CurrentVersion?.ToNormalizedString() ?? string.Empty;
     AvailableVersions = await _aresUpdater.GetAvailableVersions();
+    AvailableAresUpdateVersion = AvailableVersions?.OrderDescending().FirstOrDefault()?.ToNormalizedString() ?? string.Empty;
     AvailableLauncherVersions = await _launcherUpdater.GetAvailableVersions();
   }
 
@@ -373,6 +378,7 @@ public partial class MainViewModel : ViewModelBase
     }
 
     AvailableVersions = await _aresUpdater.GetAvailableVersions();
+    AvailableAresUpdateVersion = AvailableVersions?.OrderDescending().FirstOrDefault()?.ToNormalizedString() ?? string.Empty;
     AvailableLauncherVersions = await _launcherUpdater.GetAvailableVersions();
 
     await _databaseManager.Refresh();

--- a/ARESLauncher/ViewModels/MainViewModel.cs
+++ b/ARESLauncher/ViewModels/MainViewModel.cs
@@ -66,6 +66,7 @@ public partial class MainViewModel : ViewModelBase
     _databaseManager = databaseManager;
     _conflictManager = conflictManager;
     _isMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+    InstalledAresVersion = string.Empty;
     Editor.ConfigurationSaved += OnConfigurationSaved;
 
     UpdateDatabaseCommand = ReactiveCommand.CreateFromTask(UpdateDb);
@@ -305,6 +306,9 @@ public partial class MainViewModel : ViewModelBase
   [Reactive]
   public partial DatabaseStatus DatabaseStatus { get; private set; }
 
+  [Reactive]
+  public partial string InstalledAresVersion { get; private set; }
+
   public string AresStateDescription => _aresStateDescription.Value;
 
   public int AresComponentsRunning => _aresComponentsRunning.Value;
@@ -318,6 +322,7 @@ public partial class MainViewModel : ViewModelBase
   private async Task UpdateAvailableVersions()
   {
     await _aresBinaryManager.Refresh();
+    InstalledAresVersion = _aresBinaryManager.CurrentVersion?.ToNormalizedString() ?? string.Empty;
     AvailableVersions = await _aresUpdater.GetAvailableVersions();
     AvailableLauncherVersions = await _launcherUpdater.GetAvailableVersions();
   }
@@ -359,6 +364,7 @@ public partial class MainViewModel : ViewModelBase
     AresConditionChecked = false;
 
     await _aresBinaryManager.Refresh();
+    InstalledAresVersion = _aresBinaryManager.CurrentVersion?.ToNormalizedString() ?? string.Empty;
     AresPresent = _aresBinaryManager.CurrentVersion is not null;
     if(!AresPresent)
     {

--- a/ARESLauncher/ViewModels/UpdateConfirmationDialogViewModel.cs
+++ b/ARESLauncher/ViewModels/UpdateConfirmationDialogViewModel.cs
@@ -1,0 +1,32 @@
+using System.Reactive;
+using ARESLauncher.Models;
+using ReactiveUI;
+
+namespace ARESLauncher.ViewModels;
+
+public class UpdateConfirmationDialogViewModel : ReactiveObject
+{
+  public UpdateConfirmationDialogViewModel(UpdateConfirmationRequest request)
+  {
+    CurrentVersion = request.CurrentVersion.ToNormalizedString();
+    TargetVersion = request.TargetVersion.ToNormalizedString();
+
+    MajorUpdate = request.TargetVersion.Major > request.CurrentVersion.Major;
+    
+    ProceedCommand = ReactiveCommand.Create(() => Unit.Default);
+    CancelCommand = ReactiveCommand.Create(() => Unit.Default);
+  }
+
+  public string CurrentVersion { get; }
+  public string TargetVersion { get; }
+  
+  public bool MajorUpdate { get; }
+
+  public string Message =>
+    MajorUpdate 
+      ? $"This will update ARES from {CurrentVersion} to {TargetVersion}.\nThis is a major update and we recommend backing up your database as there is potential of data loss."
+      : $"This will update ARES from {CurrentVersion} to {TargetVersion}.\nWhile this is a minor update, we would still recommend backing up your database just to be safe.";
+
+  public ReactiveCommand<Unit, Unit> ProceedCommand { get; }
+  public ReactiveCommand<Unit, Unit> CancelCommand { get; }
+}

--- a/ARESLauncher/Views/ConfigurationEditorView.axaml
+++ b/ARESLauncher/Views/ConfigurationEditorView.axaml
@@ -41,7 +41,7 @@
             <StackPanel Spacing="12"
                         IsVisible="{Binding ShowAdvancedOptions}">
                 <Grid ColumnDefinitions="Auto,*"
-                      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
                     <TextBlock Grid.Row="0"
                                Grid.Column="0"
                                Margin="0,0,0,8"
@@ -127,8 +127,19 @@
                                Grid.Column="0"
                                Margin="0,0,0,8"
                                VerticalAlignment="Center"
+                               Text="Installed ARES layout:" />
+                    <ComboBox Grid.Row="8"
+                              Grid.Column="1"
+                              Margin="12,0,0,8"
+                              ItemsSource="{Binding ReleaseLayouts}"
+                              SelectedItem="{Binding EditableInstalledAresLayout, Mode=TwoWay}" />
+
+                    <TextBlock Grid.Row="9"
+                               Grid.Column="0"
+                               Margin="0,0,0,8"
+                               VerticalAlignment="Center"
                                Text="ARES UI process:" />
-                    <TextBox Grid.Row="8"
+                    <TextBox Grid.Row="9"
                              Grid.Column="1"
                              Margin="12,0,0,0"
                              Text="{Binding EditableAresUiProcessName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/ARESLauncher/Views/ConfigurationEditorView.axaml
+++ b/ARESLauncher/Views/ConfigurationEditorView.axaml
@@ -31,7 +31,7 @@
                          Margin="12,0,0,8"
                          Text="{Binding EditableServiceBinaryPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-                <TextBlock Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2" TextWrapping="Wrap" FontSize="10">Make sure the UI and Service path is the same if the selected ARES repo produces a combined bundle.</TextBlock>
+                <TextBlock Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2" TextWrapping="Wrap" FontSize="10">Make sure the UI and Service path is the same because ARES installs from a combined package.</TextBlock>
             </Grid>
 
             <ToggleSwitch Content="Show advanced options"
@@ -140,20 +140,16 @@
                              SelectedItem="{Binding SelectedAvailableRepository, Mode=TwoWay}">
                         <ListBox.ItemTemplate>
                             <DataTemplate x:DataType="vm:AresSourceEditorViewModel">
-                                <Grid ColumnDefinitions="*,*,Auto"
+                                <Grid ColumnDefinitions="*,*"
                                       Margin="0,0,0,8">
                                     <TextBox Grid.Column="0"
                                              Margin="0,0,8,0"
                                              Watermark="Owner"
                                              Text="{Binding Owner, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                     <TextBox Grid.Column="1"
-                                             Margin="0,0,8,0"
+                                             Margin="0,0,0,0"
                                              Watermark="Repository"
                                              Text="{Binding Repo, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                                    <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="5">
-										<TextBlock VerticalAlignment="Center">Bundle</TextBlock>
-                                        <CheckBox IsChecked="{Binding Bundle}" />
-                                    </StackPanel>
                                 </Grid>
                             </DataTemplate>
                         </ListBox.ItemTemplate>

--- a/ARESLauncher/Views/Converters/InverseBoolConverter.cs
+++ b/ARESLauncher/Views/Converters/InverseBoolConverter.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace ARESLauncher.Views.Converters;
+
+public sealed class InverseBoolConverter : IValueConverter
+{
+  public static InverseBoolConverter Instance { get; } = new();
+
+  public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+  {
+    return value is bool b ? !b : value;
+  }
+
+  public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+  {
+    return value is bool b ? !b : value;
+  }
+}

--- a/ARESLauncher/Views/MainView.axaml
+++ b/ARESLauncher/Views/MainView.axaml
@@ -90,7 +90,7 @@
                         </StackPanel>
 
                         <!-- Update notifier -->
-                        <Border Grid.Row="2" Padding="12" CornerRadius="8" Margin="8,0" Classes="boxthingy"
+                        <Border Grid.Row="2" Padding="8" CornerRadius="8" Margin="8,0" Classes="boxthingy"
                                 IsVisible="{Binding UpdateAvailable}">
                             <StackPanel Spacing="8">
                                 <Button Command="{Binding UpdateAresCommand}" HorizontalAlignment="Stretch" Classes="info">
@@ -100,7 +100,8 @@
                                     </StackPanel>
                                 </Button>
                                 <TextBlock TextWrapping="Wrap" FontSize="12"
-                                           Text="Update is available." />
+                                           TextAlignment="Center"
+                                           Text="{Binding AvailableAresUpdateVersion, StringFormat='Update available: {0}'}" />
                             </StackPanel>
                         </Border>
 

--- a/ARESLauncher/Views/MainView.axaml
+++ b/ARESLauncher/Views/MainView.axaml
@@ -77,6 +77,12 @@
                             HorizontalAlignment="Center"
                             FontSize="16"
                             Margin="0,15,0,0" />
+                            <TextBlock
+                            Text="{Binding InstalledAresVersion, StringFormat='ARES version: {0}'}"
+                            IsVisible="{Binding InstalledAresVersion, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                            HorizontalAlignment="Center"
+                            FontSize="13"
+                            Margin="0,4,0,0" />
                             <StackPanel HorizontalAlignment="Center" IsVisible="{Binding ShowDisclaimer}">
                                 <TextBlock FontSize="10" TextWrapping="Wrap">Edge and Chrome might give a "Your connection isn't private" warning.</TextBlock>
                                 <TextBlock FontSize="10" TextWrapping="Wrap">Feel free to click "Advanced" and then proceed.</TextBlock>

--- a/ARESLauncher/Views/MainWindow.axaml.cs
+++ b/ARESLauncher/Views/MainWindow.axaml.cs
@@ -38,6 +38,21 @@ public partial class MainWindow : Window
 
       interaction.SetOutput(Unit.Default);
     });
+
+    vm.UpdateConfirmationDialog.RegisterHandler(async interaction =>
+    {
+      var dialogVm = new UpdateConfirmationDialogViewModel(interaction.Input);
+      var dialog = new UpdateConfirmationDialog
+      {
+        DataContext = dialogVm
+      };
+
+      dialogVm.ProceedCommand.Subscribe(_ => dialog.Close(true));
+      dialogVm.CancelCommand.Subscribe(_ => dialog.Close(false));
+
+      var result = await dialog.ShowDialog<bool>(this);
+      interaction.SetOutput(result);
+    });
   }
 
   protected override void OnClosing(WindowClosingEventArgs e)

--- a/ARESLauncher/Views/UpdateConfirmationDialog.axaml
+++ b/ARESLauncher/Views/UpdateConfirmationDialog.axaml
@@ -1,0 +1,39 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:ARESLauncher.ViewModels"
+        mc:Ignorable="d"
+        d:DesignWidth="480"
+        d:DesignHeight="260"
+        x:Class="ARESLauncher.UpdateConfirmationDialog"
+        x:DataType="vm:UpdateConfirmationDialogViewModel"
+        Width="480"
+        Height="260"
+        CanResize="False"
+        Title="Confirm ARES Update">
+    <Border Padding="24">
+        <StackPanel Spacing="16">
+            <TextBlock Text="ARES Update"
+                       FontSize="20"
+                       FontWeight="Bold"
+                       TextAlignment="Center" />
+            <TextBlock Text="{Binding Message}"
+                       TextWrapping="Wrap"
+                       TextAlignment="Center" />
+            <TextBlock Text="Do you want to continue with this update?"
+                       TextAlignment="Center" />
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Center"
+                        Spacing="12"
+                        Margin="0,8,0,0">
+                <Button Content="Cancel"
+                        MinWidth="120"
+                        Command="{Binding CancelCommand}" />
+                <Button Content="Proceed"
+                        MinWidth="120"
+                        Command="{Binding ProceedCommand}" />
+            </StackPanel>
+        </StackPanel>
+    </Border>
+</Window>

--- a/ARESLauncher/Views/UpdateConfirmationDialog.axaml.cs
+++ b/ARESLauncher/Views/UpdateConfirmationDialog.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace ARESLauncher;
+
+public partial class UpdateConfirmationDialog : Window
+{
+  public UpdateConfirmationDialog()
+  {
+    InitializeComponent();
+  }
+}


### PR DESCRIPTION
* Added support for the new architecture of just one executable file (the UI). If the bundle only contains the UI executable, everything should now run through that executable including the database checks and migrations.
    * This maintains the backwards compatibility with the previous architecture so that updating should be pretty painless.

* Added a confirmation dialog cautioning the user that they're about to have a minor or major update and they should backup their data.

* Removed the support for separate UI and Service bundles in order to reduce bloat.

* Added some vibe coded tests... They seem legit at first glance and I didn't dive too deep, but they seem to be testing what they're supposed to.