### PR TITLE
BETA Version Support + Database Rollback

### DIFF
--- a/ARESLauncher.Tests/AresUpdaterTests.cs
+++ b/ARESLauncher.Tests/AresUpdaterTests.cs
@@ -1,5 +1,3 @@
-using System.IO;
-using System.Threading.Tasks;
 using ARESLauncher.Configuration;
 using ARESLauncher.Models;
 using ARESLauncher.Services;
@@ -81,6 +79,134 @@ public class AresUpdaterTests
   }
 
   [Test]
+  public async Task GetAvailableVersions_IncludesDebugFolderPackages()
+  {
+    var debugPath = Path.Combine(AppContext.BaseDirectory, "Debug");
+    Directory.CreateDirectory(debugPath);
+    var version = new SemanticVersion(8, 8, 8);
+    var archiveName = $"ARES-v{version.ToNormalizedString()}.zip";
+    var archivePath = TestArchives.CreateArchive(debugPath, archiveName, ("empty", ""));
+
+    try
+    {
+      var downloader = new RecordingAresDownloader(null);
+      downloader.AvailableReleases = [new AresRelease { Version = new SemanticVersion(1, 0, 0), IsBeta = false }];
+
+      var updater = new AresUpdater(
+        downloader,
+        new FakeAppConfigurationService(new LauncherConfiguration()),
+        new FakeAppSettingsUpdater(),
+        new FakeCertificateManager(),
+        new FakeDatabaseManager(),
+        new FakeAresBinaryManager(),
+        NullLogger<AresUpdater>.Instance);
+
+      var releases = await updater.GetAvailableVersions();
+
+      Assert.That(releases.Select(r => r.Version), Does.Contain(version));
+      Assert.That(releases.Select(r => r.Version), Does.Contain(new SemanticVersion(1, 0, 0)));
+    }
+    finally
+    {
+      if(File.Exists(archivePath)) File.Delete(archivePath);
+    }
+  }
+
+  [Test]
+  public async Task GetAvailableVersions_FiltersBetaReleases_WhenNotOptedIn()
+  {
+      var downloader = new RecordingAresDownloader(null);
+      downloader.AvailableReleases = [
+          new AresRelease { Version = new SemanticVersion(1, 0, 0), IsBeta = false },
+          new AresRelease { Version = new SemanticVersion(1, 1, 0), IsBeta = true }
+      ];
+
+      var updater = new AresUpdater(
+        downloader,
+        new FakeAppConfigurationService(new LauncherConfiguration { IncludeBeta = false }),
+        new FakeAppSettingsUpdater(),
+        new FakeCertificateManager(),
+        new FakeDatabaseManager(),
+        new FakeAresBinaryManager(),
+        NullLogger<AresUpdater>.Instance);
+
+      var releases = await updater.GetAvailableVersions();
+
+      Assert.That(releases.Select(r => r.Version), Does.Contain(new SemanticVersion(1, 0, 0)));
+      Assert.That(releases.Select(r => r.Version), Does.Not.Contain(new SemanticVersion(1, 1, 0)));
+  }
+
+  [Test]
+  public async Task GetAvailableVersions_IncludesBetaReleases_WhenOptedIn()
+  {
+      var downloader = new RecordingAresDownloader(null);
+      downloader.AvailableReleases = [
+          new AresRelease { Version = new SemanticVersion(1, 0, 0), IsBeta = false },
+          new AresRelease { Version = new SemanticVersion(1, 1, 0), IsBeta = true }
+      ];
+
+      var updater = new AresUpdater(
+        downloader,
+        new FakeAppConfigurationService(new LauncherConfiguration { IncludeBeta = true }),
+        new FakeAppSettingsUpdater(),
+        new FakeCertificateManager(),
+        new FakeDatabaseManager(),
+        new FakeAresBinaryManager(),
+        NullLogger<AresUpdater>.Instance);
+
+      var releases = await updater.GetAvailableVersions();
+
+      Assert.That(releases.Select(r => r.Version), Does.Contain(new SemanticVersion(1, 0, 0)));
+      Assert.That(releases.Select(r => r.Version), Does.Contain(new SemanticVersion(1, 1, 0)));
+  }
+
+  [Test]
+  public async Task Update_UsesDebugFolderPackage_WhenAvailable()
+  {
+    var debugPath = Path.Combine(AppContext.BaseDirectory, "Debug");
+    Directory.CreateDirectory(debugPath);
+    var tempRoot = TestPaths.CreateTempDirectory();
+    var uiDir = Path.Combine(tempRoot, "ui");
+    Directory.CreateDirectory(uiDir);
+
+    var version = new SemanticVersion(9, 9, 9);
+    var archiveName = $"ARES-v{version.ToNormalizedString()}.zip";
+    var archivePath = TestArchives.CreateArchive(debugPath, archiveName, ("debug.bin", "content"));
+
+    try
+    {
+      var downloader = new RecordingAresDownloader(null); // Should not be called
+      var configuration = new FakeAppConfigurationService(new LauncherConfiguration
+      {
+        UiBinaryPath = uiDir,
+        ServiceBinaryPath = uiDir
+      });
+
+      var updater = new AresUpdater(
+        downloader,
+        configuration,
+        new FakeAppSettingsUpdater(),
+        new FakeCertificateManager(),
+        new FakeDatabaseManager(),
+        new FakeAresBinaryManager(),
+        NullLogger<AresUpdater>.Instance);
+
+      await updater.Update(version);
+
+      Assert.That(downloader.DownloadCallCount, Is.EqualTo(0));
+      Assert.That(File.Exists(Path.Combine(uiDir, "debug.bin")), Is.True);
+
+      var metadata = BinaryMetadataHelper.ReadMetadata(uiDir);
+      Assert.That(metadata!.Version, Is.EqualTo(version.ToNormalizedString()));
+    }
+    finally
+    {
+      if(File.Exists(archivePath)) File.Delete(archivePath);
+      TestPaths.DeleteDirectoryIfExists(tempRoot);
+    }
+  }
+
+  [Test]
   public async Task Update_PersistsSplitLayout_WhenServiceExecutableExists()
   {
     var tempRoot = TestPaths.CreateTempDirectory();
@@ -88,7 +214,8 @@ public class AresUpdaterTests
 
     try
     {
-      var archivePath = TestArchives.CreateArchive(tempRoot, "combined.zip", ("UI", "ui"), ("AresService", "svc"));
+      var serviceName = OperatingSystem.IsWindows() ? "AresService.exe" : "AresService";
+      var archivePath = TestArchives.CreateArchive(tempRoot, "combined.zip", ("UI", "ui"), (serviceName, "svc"));
       var source = new AresSource("AFRL-ARES", "ARES");
       var version = new SemanticVersion(2, 0, 0);
       var downloader = new RecordingAresDownloader(archivePath);
@@ -119,5 +246,81 @@ public class AresUpdaterTests
     {
       TestPaths.DeleteDirectoryIfExists(tempRoot);
     }
+  }
+
+  [Test]
+  public void InvalidateCache_DelegatesToDownloader()
+  {
+    var downloader = new RecordingAresDownloader(null);
+    var updater = new AresUpdater(
+      downloader,
+      new FakeAppConfigurationService(new LauncherConfiguration()),
+      new FakeAppSettingsUpdater(),
+      new FakeCertificateManager(),
+      new FakeDatabaseManager(),
+      new FakeAresBinaryManager(),
+      NullLogger<AresUpdater>.Instance);
+
+    updater.InvalidateCache();
+
+    Assert.That(downloader.InvalidateCacheCalled, Is.True);
+  }
+
+  [Test]
+  public async Task CreateSnapshot_CallsDatabaseManagerCreateSnapshot()
+  {
+    var dbManager = new FakeDatabaseManager();
+    var updater = new AresUpdater(
+      new RecordingAresDownloader(null),
+      new FakeAppConfigurationService(new LauncherConfiguration()),
+      new FakeAppSettingsUpdater(),
+      new FakeCertificateManager(),
+      dbManager,
+      new FakeAresBinaryManager(),
+      NullLogger<AresUpdater>.Instance);
+
+    var version = new SemanticVersion(1, 0, 0);
+    await updater.CreateSnapshot(version);
+
+    Assert.That(dbManager.CreateSnapshotCallCount, Is.EqualTo(1));
+    Assert.That(dbManager.LastSnapshotVersion, Is.EqualTo(version));
+  }
+
+  [Test]
+  public async Task RestoreSnapshot_CallsDatabaseManagerRestoreSnapshot()
+  {
+    var dbManager = new FakeDatabaseManager();
+    var updater = new AresUpdater(
+      new RecordingAresDownloader(null),
+      new FakeAppConfigurationService(new LauncherConfiguration()),
+      new FakeAppSettingsUpdater(),
+      new FakeCertificateManager(),
+      dbManager,
+      new FakeAresBinaryManager(),
+      NullLogger<AresUpdater>.Instance);
+
+    var version = new SemanticVersion(1, 0, 0);
+    await updater.RestoreSnapshot(version);
+
+    Assert.That(dbManager.RestoreSnapshotCallCount, Is.EqualTo(1));
+    Assert.That(dbManager.LastRestoreVersion, Is.EqualTo(version));
+  }
+
+  [Test]
+  public async Task ResetDatabase_CallsDatabaseManagerReset()
+  {
+    var dbManager = new FakeDatabaseManager();
+    var updater = new AresUpdater(
+      new RecordingAresDownloader(null),
+      new FakeAppConfigurationService(new LauncherConfiguration()),
+      new FakeAppSettingsUpdater(),
+      new FakeCertificateManager(),
+      dbManager,
+      new FakeAresBinaryManager(),
+      NullLogger<AresUpdater>.Instance);
+
+    await updater.ResetDatabase();
+
+    Assert.That(dbManager.DatabaseStatus, Is.EqualTo(DatabaseStatus.NonExistent));
   }
 }

--- a/ARESLauncher.Tests/TestSupport/TestDoubles.cs
+++ b/ARESLauncher.Tests/TestSupport/TestDoubles.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 using ARESLauncher.Configuration;
 using ARESLauncher.Models;
 using ARESLauncher.Models.AppSettings;
@@ -9,22 +7,29 @@ using NuGet.Versioning;
 
 namespace ARESLauncher.Tests;
 
-internal sealed class RecordingAresDownloader(string archivePath) : IAresDownloader
+internal sealed class RecordingAresDownloader(string? archivePath) : IAresDownloader
 {
   public int DownloadCallCount { get; private set; }
+  public bool InvalidateCacheCalled { get; private set; }
   public AresSource? LastSource { get; private set; }
   public SemanticVersion? LastVersion { get; private set; }
   public string? LastDestination { get; private set; }
   public string? LastAuthToken { get; private set; }
+  public AresRelease[] AvailableReleases { get; set; } = [];
 
-  public Task<SemanticVersion[]> GetAvailableVersions(AresSource source, string? authToken)
+  public Task<AresRelease[]> GetAvailableVersions(AresSource source, string? authToken)
   {
-    throw new NotSupportedException();
+    return Task.FromResult(AvailableReleases);
   }
 
-  public Task<SemanticVersion[]> GetAvailableVersions(LauncherSource soruce)
+  public Task<AresRelease[]> GetAvailableVersions(LauncherSource source, string? authToken)
   {
-    throw new NotSupportedException();
+    return Task.FromResult(AvailableReleases);
+  }
+
+  public void InvalidateCache()
+  {
+    InvalidateCacheCalled = true;
   }
 
   public Task<string> Download(LauncherSource source, SemanticVersion version, string destination, string? authToken,
@@ -42,7 +47,7 @@ internal sealed class RecordingAresDownloader(string archivePath) : IAresDownloa
     LastDestination = destination;
     LastAuthToken = authToken;
     progress?.Report(1);
-    return Task.FromResult(archivePath);
+    return Task.FromResult(archivePath ?? throw new InvalidOperationException("Archive path not set"));
   }
 }
 
@@ -86,13 +91,43 @@ internal sealed class FakeCertificateManager : ICertificateManager
 
 internal sealed class FakeDatabaseManager : IDatabaseManager
 {
-  public DatabaseStatus DatabaseStatus => DatabaseStatus.UpToDate;
+  public DatabaseStatus DatabaseStatus { get; set; } = DatabaseStatus.UpToDate;
   public int RefreshCallCount { get; private set; }
   public int RunMigrationsCallCount { get; private set; }
+  public int CreateSnapshotCallCount { get; private set; }
+  public int RestoreSnapshotCallCount { get; private set; }
+  public SemanticVersion? LastSnapshotVersion { get; private set; }
+  public SemanticVersion? LastRestoreVersion { get; private set; }
+  public bool SnapshotExistsResult { get; set; }
 
   public Task RunMigrations()
   {
     RunMigrationsCallCount++;
+    return Task.CompletedTask;
+  }
+
+  public Task CreateSnapshot(SemanticVersion version)
+  {
+    CreateSnapshotCallCount++;
+    LastSnapshotVersion = version;
+    return Task.CompletedTask;
+  }
+
+  public Task<bool> HasSnapshot(SemanticVersion version)
+  {
+    return Task.FromResult(SnapshotExistsResult);
+  }
+
+  public Task RestoreSnapshot(SemanticVersion version)
+  {
+    RestoreSnapshotCallCount++;
+    LastRestoreVersion = version;
+    return Task.CompletedTask;
+  }
+
+  public Task Reset()
+  {
+    DatabaseStatus = DatabaseStatus.NonExistent;
     return Task.CompletedTask;
   }
 

--- a/ARESLauncher/Configuration/LauncherConfiguration.cs
+++ b/ARESLauncher/Configuration/LauncherConfiguration.cs
@@ -41,4 +41,5 @@ public class LauncherConfiguration
 
   public string AresServiceProcessName { get; set; } = "AresService";
   public string AresUiProcessName { get; set; } = "UI";
+  public bool IncludeBeta { get; set; } = false;
 }

--- a/ARESLauncher/Models/AppSettings/AppSettingsService.cs
+++ b/ARESLauncher/Models/AppSettings/AppSettingsService.cs
@@ -3,5 +3,4 @@ namespace ARESLauncher.Models.AppSettings;
 public class AppSettingsService : AppSettingsBase
 {
   public TokensConfig? TokensConfig { get; set; }
-  public string? AresDataPath { get; set; }
 }

--- a/ARESLauncher/Models/AresRelease.cs
+++ b/ARESLauncher/Models/AresRelease.cs
@@ -1,0 +1,15 @@
+using NuGet.Versioning;
+
+namespace ARESLauncher.Models;
+
+public class AresRelease
+{
+  public required SemanticVersion Version { get; init; }
+  public required bool IsBeta { get; init; }
+  public bool IsInstalled { get; set; }
+
+  public override string ToString()
+  {
+    return IsBeta ? $"{Version} (Beta)" : Version.ToString();
+  }
+}

--- a/ARESLauncher/Models/UpdateConfirmationRequest.cs
+++ b/ARESLauncher/Models/UpdateConfirmationRequest.cs
@@ -2,8 +2,26 @@ using NuGet.Versioning;
 
 namespace ARESLauncher.Models;
 
+public enum DowngradeOption
+{
+  None,
+  RestoreSnapshot,
+  Reset,
+  Cancel
+}
+
 public class UpdateConfirmationRequest
 {
   public required SemanticVersion CurrentVersion { get; init; }
   public required SemanticVersion TargetVersion { get; init; }
+  public bool HasSnapshot { get; set; }
+}
+
+public class UpdateConfirmationResponse
+{
+  public bool ShouldProceed { get; init; }
+  public DowngradeOption DowngradeOption { get; init; } = DowngradeOption.None;
+
+  public static UpdateConfirmationResponse Cancel => new() { ShouldProceed = false, DowngradeOption = DowngradeOption.Cancel };
+  public static UpdateConfirmationResponse Proceed(DowngradeOption option = DowngradeOption.None) => new() { ShouldProceed = true, DowngradeOption = option };
 }

--- a/ARESLauncher/Services/AresGithubDownloader.cs
+++ b/ARESLauncher/Services/AresGithubDownloader.cs
@@ -14,19 +14,38 @@ namespace ARESLauncher.Services;
 public partial class AresGithubDownloader(ILogger<AresGithubDownloader> _logger) : IAresDownloader
 {
   private static readonly ApiOptions _fetchOptions = new() { PageCount = 2, PageSize = 10 };
+  private static readonly Dictionary<string, (AresRelease[] releases, DateTime timestamp)> _cache = new();
+  private static readonly TimeSpan _cacheDuration = TimeSpan.FromSeconds(30);
 
-  public async Task<SemanticVersion[]> GetAvailableVersions(AresSource source, string? authToken)
+  public async Task<AresRelease[]> GetAvailableVersions(AresSource source, string? authToken)
   {
-    var client = CreateClient(authToken);
-    var versions = await FetchAndNormalizeVersions(client, source.Owner, source.Repo);
-    return versions.ToArray();
+    return await GetCachedVersions(authToken, source.Owner, source.Repo);
   }
 
-  public async Task<SemanticVersion[]> GetAvailableVersions(LauncherSource source)
+  public async Task<AresRelease[]> GetAvailableVersions(LauncherSource source, string? authToken)
   {
-    var client = CreateClient("");
-    var versions = await FetchAndNormalizeVersions(client, source.Owner, source.Repo);
-    return versions.ToArray();
+    return await GetCachedVersions(authToken, source.Owner, source.Repo);
+  }
+
+  private async Task<AresRelease[]> GetCachedVersions(string? authToken, string owner, string repo)
+  {
+    var cacheKey = $"{owner}/{repo}/{authToken ?? ""}";
+    if(_cache.TryGetValue(cacheKey, out var cached) && DateTime.UtcNow - cached.timestamp < _cacheDuration)
+    {
+      return cached.releases;
+    }
+
+    var client = CreateClient(authToken);
+    var versions = await FetchAndNormalizeVersions(client, owner, repo);
+    var result = versions.ToArray();
+    
+    _cache[cacheKey] = (result, DateTime.UtcNow);
+    return result;
+  }
+
+  public void InvalidateCache()
+  {
+    _cache.Clear();
   }
 
   public async Task<string> Download(LauncherSource source, SemanticVersion version, string destination, string? authToken,
@@ -46,9 +65,9 @@ public partial class AresGithubDownloader(ILogger<AresGithubDownloader> _logger)
       : downloadResult.ResultingFilePath!;
   }
 
-  private async Task<List<SemanticVersion>> FetchAndNormalizeVersions(GitHubClient client, string owner, string repo)
+  private async Task<List<AresRelease>> FetchAndNormalizeVersions(GitHubClient client, string owner, string repo)
   {
-    var versions = new List<SemanticVersion>();
+    var versions = new List<AresRelease>();
 
     try
     {
@@ -61,7 +80,7 @@ public partial class AresGithubDownloader(ILogger<AresGithubDownloader> _logger)
           continue;
 
         if(SemanticVersion.TryParse(normalizedTag, out var semanticVersion))
-          versions.Add(semanticVersion);
+          versions.Add(new AresRelease { Version = semanticVersion, IsBeta = release.Prerelease });
       }
     }
 

--- a/ARESLauncher/Services/AresStarter.cs
+++ b/ARESLauncher/Services/AresStarter.cs
@@ -16,6 +16,7 @@ public class AresStarter : IAresStarter
 {
   private readonly IAresBinaryManager _aresBinaryManager;
   private readonly IExecutableGetter _executableGetter;
+  private readonly IDatabaseManager _databaseManager;
   private readonly ILogger<AresStarter> _logger;
   private readonly BehaviorSubject<bool> _aresUiRunningSubject = new(false);
   private readonly BehaviorSubject<bool> _aresServiceRunningSubject = new(false);
@@ -26,10 +27,11 @@ public class AresStarter : IAresStarter
   private CancellationTokenSource _cancellationTokenSource = new();
   private int _stopInitiated = 0;
 
-  public AresStarter(IAresBinaryManager aresBinaryManager, IExecutableGetter executableGetter, ILogger<AresStarter> logger)
+  public AresStarter(IAresBinaryManager aresBinaryManager, IExecutableGetter executableGetter, IDatabaseManager databaseManager, ILogger<AresStarter> logger)
   {
     _aresBinaryManager = aresBinaryManager;
     _executableGetter = executableGetter;
+    _databaseManager = databaseManager;
     _logger = logger;
     AresUiRunning = _aresUiRunningSubject.AsObservable();
     AresServiceRunning = _aresServiceRunningSubject.AsObservable();
@@ -38,12 +40,25 @@ public class AresStarter : IAresStarter
   public IObservable<bool> AresUiRunning { get; }
   public IObservable<bool> AresServiceRunning { get; }
 
-  public void Start()
+  public async void Start()
   {
     if(IsHealthyRunning())
     {
       _logger.LogDebug("Start requested while ARES is already running. Skipping.");
       return;
+    }
+
+    var currentVersion = _aresBinaryManager.CurrentVersion;
+    if(currentVersion is not null)
+    {
+      try
+      {
+        await _databaseManager.CreateSnapshot(currentVersion);
+      }
+      catch(Exception e)
+      {
+        _logger.LogWarning("Failed to create database snapshot before start: {Exception}", e);
+      }
     }
 
     _cancellationTokenSource = new CancellationTokenSource();

--- a/ARESLauncher/Services/AresUpdater.cs
+++ b/ARESLauncher/Services/AresUpdater.cs
@@ -45,10 +45,44 @@ public class AresUpdater : IAresUpdater
     CurrentUpdateStep = _currentUpdateStepSubject.AsObservable();
   }
 
-  public Task<SemanticVersion[]> GetAvailableVersions()
+  public async Task<AresRelease[]> GetAvailableVersions()
   {
     var source = _configurationService.Current.CurrentAresRepo;
-    return _downloader.GetAvailableVersions(source, _configurationService.Current.GitToken);
+    var remoteReleases = await _downloader.GetAvailableVersions(source, _configurationService.Current.GitToken);
+    var localDebugVersions = GetLocalDebugVersions();
+
+    var allReleases = remoteReleases.Union(localDebugVersions.Select(v => new AresRelease { Version = v, IsBeta = false }))
+      .OrderByDescending(r => r.Version);
+
+    if(!_configurationService.Current.IncludeBeta)
+    {
+      return allReleases.Where(r => !r.IsBeta).ToArray();
+    }
+
+    return allReleases.ToArray();
+  }
+
+  private SemanticVersion[] GetLocalDebugVersions()
+  {
+    var debugPath = Path.Combine(AppContext.BaseDirectory, "Debug");
+    if(!Directory.Exists(debugPath))
+      return Array.Empty<SemanticVersion>();
+
+    return Directory.EnumerateFiles(debugPath, "*.zip")
+      .Select(f =>
+      {
+        try
+        {
+          return Tools.VersionExtensions.GetVersionFromZipName(Path.GetFileName(f));
+        }
+        catch(Exception)
+        {
+          return null;
+        }
+      })
+      .Where(v => v is not null)
+      .Cast<SemanticVersion>()
+      .ToArray();
   }
 
   public async Task InstallOffline(string path)
@@ -147,7 +181,7 @@ public class AresUpdater : IAresUpdater
       return;
     }
 
-    var latest = versions.OrderDescending().FirstOrDefault();
+    var latest = versions.FirstOrDefault();
     if(latest is null)
     {
       _currentUpdateStepSubject.OnNext(UpdateStep.Idle);
@@ -155,7 +189,62 @@ public class AresUpdater : IAresUpdater
       throw new InvalidOperationException("No ARES versions found. Ensure the right repository is selected and/or your Git token is correct.");
     }
 
-    await Update(latest);
+    await Update(latest.Version);
+  }
+
+  public async Task CreateSnapshot(SemanticVersion version)
+  {
+    _currentUpdateStepSubject.OnNext(UpdateStep.Other);
+    _updateStepDescriptionSubject.OnNext("Creating database snapshot");
+    try
+    {
+      await _databaseManager.CreateSnapshot(version);
+    }
+    finally
+    {
+      _currentUpdateStepSubject.OnNext(UpdateStep.Idle);
+      _updateStepDescriptionSubject.OnNext("");
+    }
+  }
+
+  public Task<bool> HasSnapshot(SemanticVersion version)
+  {
+    return _databaseManager.HasSnapshot(version);
+  }
+
+  public async Task RestoreSnapshot(SemanticVersion version)
+  {
+    _currentUpdateStepSubject.OnNext(UpdateStep.Other);
+    _updateStepDescriptionSubject.OnNext("Restoring database snapshot");
+    try
+    {
+      await _databaseManager.RestoreSnapshot(version);
+    }
+    finally
+    {
+      _currentUpdateStepSubject.OnNext(UpdateStep.Idle);
+      _updateStepDescriptionSubject.OnNext("");
+    }
+  }
+
+  public async Task ResetDatabase()
+  {
+    _currentUpdateStepSubject.OnNext(UpdateStep.Other);
+    _updateStepDescriptionSubject.OnNext("Resetting database");
+    try
+    {
+      await _databaseManager.Reset();
+    }
+    finally
+    {
+      _currentUpdateStepSubject.OnNext(UpdateStep.Idle);
+      _updateStepDescriptionSubject.OnNext("");
+    }
+  }
+
+  public void InvalidateCache()
+  {
+    _downloader.InvalidateCache();
   }
 
   public IObservable<string> UpdateStepDescription { get; }
@@ -167,9 +256,37 @@ public class AresUpdater : IAresUpdater
     var tempPath = Path.GetTempPath();
     try
     {
-      _updateStepDescriptionSubject.OnNext("Downloading the package.");
-      var packageDest = await _downloader.Download(source, version, tempPath, _configurationService.Current.GitToken,
-        new Progress<double>(pg => _updateProgressSubject.OnNext(pg)));
+      string packageDest;
+      var debugPath = Path.Combine(AppContext.BaseDirectory, "Debug");
+      var localPackage = Directory.Exists(debugPath)
+        ? Directory.EnumerateFiles(debugPath, "*.zip")
+          .FirstOrDefault(f =>
+          {
+            try
+            {
+              return version.Equals(Tools.VersionExtensions.GetVersionFromZipName(Path.GetFileName(f)));
+            }
+            catch(Exception)
+            {
+              return false;
+            }
+          })
+        : null;
+
+      if(localPackage != null)
+      {
+        _logger.LogInformation("Using local debug package for version {Version}: {Path}", version, localPackage);
+        _updateStepDescriptionSubject.OnNext("Using local debug package.");
+        _updateProgressSubject.OnNext(1.0);
+        packageDest = localPackage;
+      }
+      else
+      {
+        _updateStepDescriptionSubject.OnNext("Downloading the package.");
+        packageDest = await _downloader.Download(source, version, tempPath, _configurationService.Current.GitToken,
+          new Progress<double>(pg => _updateProgressSubject.OnNext(pg)));
+      }
+
       _updateStepDescriptionSubject.OnNext("Unpacking the package");
       await Unpacker.Unpack(packageDest, dest);
       var layout = DetectInstalledLayout(dest);

--- a/ARESLauncher/Services/DatabaseManager.cs
+++ b/ARESLauncher/Services/DatabaseManager.cs
@@ -14,10 +14,8 @@ public class DatabaseManager(IExecutableGetter _executableGetter, IAppConfigurat
   public async Task RunMigrations()
   {
     var executable = GetDatabaseExecutablePath();
-    if (executable is null)
-    {
+    if(executable is null)
       return;
-    }
 
     var workingDir = GetWorkingDir(executable);
     await Cli.Wrap(executable)
@@ -31,10 +29,8 @@ public class DatabaseManager(IExecutableGetter _executableGetter, IAppConfigurat
   public async Task Refresh()
   {
     var executable = GetDatabaseExecutablePath();
-    if (executable is null)
-    {
+    if(executable is null)
       return;
-    }
 
     var workingDir = GetWorkingDir(executable);
     var checkResult = await Cli.Wrap(executable)
@@ -44,6 +40,80 @@ public class DatabaseManager(IExecutableGetter _executableGetter, IAppConfigurat
       .ExecuteAsync();
     
     DatabaseStatus = ExitCodeToDbStatus.GetDatabaseStatus(checkResult.ExitCode);
+  }
+
+  public Task CreateSnapshot(NuGet.Versioning.SemanticVersion version)
+  {
+    if(_configurationService.Current.DatabaseProvider != DatabaseProvider.Sqlite)
+      return Task.CompletedTask;
+
+    var dbPath = _configurationService.Current.SqliteDatabasePath;
+    if(!File.Exists(dbPath)) return Task.CompletedTask;
+
+    var snapshotPath = GetSnapshotPath(version);
+    var snapshotDir = Path.GetDirectoryName(snapshotPath);
+    if(snapshotDir is not null) Directory.CreateDirectory(snapshotDir);
+
+    File.Copy(dbPath, snapshotPath, true);
+    return Task.CompletedTask;
+  }
+
+  public Task<bool> HasSnapshot(NuGet.Versioning.SemanticVersion version)
+  {
+    if(_configurationService.Current.DatabaseProvider != DatabaseProvider.Sqlite)
+      return Task.FromResult(false);
+
+    var snapshotPath = GetSnapshotPath(version);
+    return Task.FromResult(File.Exists(snapshotPath));
+  }
+
+  public async Task RestoreSnapshot(NuGet.Versioning.SemanticVersion version)
+  {
+    try
+    {
+      if(_configurationService.Current.DatabaseProvider != DatabaseProvider.Sqlite)
+        return;
+
+      var snapshotPath = GetSnapshotPath(version);
+      if(!File.Exists(snapshotPath))
+        return;
+
+      var dbPath = _configurationService.Current.SqliteDatabasePath;
+      var dbDir = Path.GetDirectoryName(dbPath);
+      if(dbDir is not null)
+        Directory.CreateDirectory(dbDir);
+
+      File.Copy(snapshotPath, dbPath, true);
+      await Refresh();
+    }
+
+    catch(Exception e)
+    {
+      Console.WriteLine($"Failed to restore snapshot! {e.Message}");
+    }
+
+  }
+
+  public Task Reset()
+  {
+    if(_configurationService.Current.DatabaseProvider == DatabaseProvider.Sqlite)
+    {
+      var dbPath = _configurationService.Current.SqliteDatabasePath;
+      if(File.Exists(dbPath))
+        File.Delete(dbPath);
+    }
+
+    DatabaseStatus = DatabaseStatus.NonExistent;
+    return Task.CompletedTask;
+  }
+
+  private string GetSnapshotPath(NuGet.Versioning.SemanticVersion version)
+  {
+    var dbPath = _configurationService.Current.SqliteDatabasePath;
+    var dbDir = Path.GetDirectoryName(dbPath) ?? "";
+    var fileName = Path.GetFileNameWithoutExtension(dbPath);
+    var extension = Path.GetExtension(dbPath);
+    return Path.Combine(dbDir, "Snapshots", $"{fileName}_v{version.ToNormalizedString()}{extension}.bak");
   }
 
   private string? GetDatabaseExecutablePath()
@@ -56,7 +126,7 @@ public class DatabaseManager(IExecutableGetter _executableGetter, IAppConfigurat
   private static string GetWorkingDir(string path)
   {
     var workingDir = Path.GetDirectoryName(path);
-    if (workingDir is null)
+    if(workingDir is null)
     {
       workingDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
       workingDir = Path.Combine(workingDir, "ARES");

--- a/ARESLauncher/Services/IAresDownloader.cs
+++ b/ARESLauncher/Services/IAresDownloader.cs
@@ -12,9 +12,9 @@ namespace ARESLauncher.Services;
 /// </summary>
 public interface IAresDownloader
 {
-  Task<SemanticVersion[]> GetAvailableVersions(AresSource source, string? authToken);
+  Task<AresRelease[]> GetAvailableVersions(AresSource source, string? authToken);
 
-  Task<SemanticVersion[]> GetAvailableVersions(LauncherSource soruce);
+  Task<AresRelease[]> GetAvailableVersions(LauncherSource source, string? authToken);
 
   Task<string> Download(LauncherSource source, SemanticVersion version, string destination, string? authToken,
     IProgress<double>? progress = null);
@@ -24,4 +24,6 @@ public interface IAresDownloader
   /// </summary>
   Task<string> Download(AresSource source, SemanticVersion version, string destination, string? authToken,
     IProgress<double>? progress = null);
+
+  void InvalidateCache();
 }

--- a/ARESLauncher/Services/IAresUpdater.cs
+++ b/ARESLauncher/Services/IAresUpdater.cs
@@ -13,9 +13,19 @@ public interface IAresUpdater
 
   IObservable<double> UpdateProgress { get; }
 
-  Task<SemanticVersion[]> GetAvailableVersions();
+  Task<AresRelease[]> GetAvailableVersions();
 
   Task Update(SemanticVersion version);
 
   Task UpdateLatest();
+
+  Task CreateSnapshot(SemanticVersion version);
+
+  Task<bool> HasSnapshot(SemanticVersion version);
+
+  Task RestoreSnapshot(SemanticVersion version);
+
+  Task ResetDatabase();
+
+  void InvalidateCache();
 }

--- a/ARESLauncher/Services/IDatabaseManager.cs
+++ b/ARESLauncher/Services/IDatabaseManager.cs
@@ -7,6 +7,10 @@ public interface IDatabaseManager
 {
   DatabaseStatus DatabaseStatus { get; }
   Task RunMigrations();
+  Task CreateSnapshot(NuGet.Versioning.SemanticVersion version);
+  Task<bool> HasSnapshot(NuGet.Versioning.SemanticVersion version);
+  Task RestoreSnapshot(NuGet.Versioning.SemanticVersion version);
+  Task Reset();
   
   /// <summary>
   /// Refreshes the status of the database as reported from the Ares Service

--- a/ARESLauncher/Services/LauncherUpdater.cs
+++ b/ARESLauncher/Services/LauncherUpdater.cs
@@ -24,10 +24,11 @@ public class LauncherUpdater : ILauncherUpdater
     _configurationService = configurationService;
   }
 
-  public Task<SemanticVersion[]> GetAvailableVersions()
+  public async Task<SemanticVersion[]> GetAvailableVersions()
   {
     var source = _configurationService.Current.LauncherSource;
-    return _downloader.GetAvailableVersions(source);
+    var releases = await _downloader.GetAvailableVersions(source, _configurationService.Current.GitToken);
+    return releases.Select(r => r.Version).ToArray();
   }
 
   public async Task<bool> UpdateLatest()

--- a/ARESLauncher/Tools/AresVersionRegex.cs
+++ b/ARESLauncher/Tools/AresVersionRegex.cs
@@ -4,6 +4,6 @@ namespace ARESLauncher.Tools;
 
 public static partial class AresVersionRegex
 {
-  [GeneratedRegex("v([\\d.]+)")]
+  [GeneratedRegex("v(\\d+(?:\\.\\d+)*)")]
   public static partial Regex VersionRegex();
 }

--- a/ARESLauncher/Tools/Unpacker.cs
+++ b/ARESLauncher/Tools/Unpacker.cs
@@ -30,10 +30,18 @@ public static class Unpacker
 
   private static void ExtractArchive(string archivePath, string destinationPath)
   {
-    var extension = Path.GetExtension(archivePath);
-    if (!string.Equals(extension, ".zip", StringComparison.OrdinalIgnoreCase))
-      throw new NotSupportedException($"Unsupported archive type \"{extension}\".");
+    try
+    {
+      var extension = Path.GetExtension(archivePath);
+      if(!string.Equals(extension, ".zip", StringComparison.OrdinalIgnoreCase))
+        throw new NotSupportedException($"Unsupported archive type \"{extension}\".");
 
-    ZipFile.ExtractToDirectory(archivePath, destinationPath, true);
+      ZipFile.ExtractToDirectory(archivePath, destinationPath, true);
+    }
+
+    catch(Exception ex)
+    {
+      Console.WriteLine(ex.Message);
+    }
   }
 }

--- a/ARESLauncher/Tools/VersionExtensions.cs
+++ b/ARESLauncher/Tools/VersionExtensions.cs
@@ -10,24 +10,29 @@ public static class VersionExtensions
   public static bool IsGreatest(this SemanticVersion version, IEnumerable<SemanticVersion> versionsToCheck)
   {
     var versions = versionsToCheck.ToArray();
+
     if(!versions.Any())
       return true;
 
     var latest = versions[0];
+
     for(var i = 1; i < versions.Length; i++)
       if(versions[i] > latest)
         latest = versions[i];
+
     return version >= latest;
   }
+
+  public static bool IsGreatest(this SemanticVersion version, IEnumerable<ARESLauncher.Models.AresRelease> releasesToCheck)
+    => version.IsGreatest(releasesToCheck.Select(r => r.Version));
+  
 
   public static SemanticVersion GetVersionFromZipName(string fileName)
   {
     var match = AresVersionRegex.VersionRegex().Match(fileName);
 
     if(match.Success && Version.TryParse(match.Groups[1].Value, out var v))
-    {
       return new SemanticVersion(v.Major, v.Minor, v.Build);
-    }
 
     throw new ArgumentException($"Invalid version in filename: {fileName}");
   }

--- a/ARESLauncher/ViewModels/ConfigurationEditorViewModel.cs
+++ b/ARESLauncher/ViewModels/ConfigurationEditorViewModel.cs
@@ -1,6 +1,7 @@
 using ARESLauncher.Models;
 using ARESLauncher.Services;
 using ARESLauncher.Services.Configuration;
+using NuGet.Versioning;
 using ReactiveUI;
 using ReactiveUI.SourceGenerators;
 using System;
@@ -9,6 +10,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Threading.Tasks;
 
 namespace ARESLauncher.ViewModels;
 
@@ -16,13 +18,20 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
 {
   private readonly IAppConfigurationService _configurationService;
   private readonly IAppSettingsUpdater _appSettingsUpdater;
+  private readonly IAresUpdater _aresUpdater;
+  private readonly IAresBinaryManager _aresBinaryManager;
   private readonly IReadOnlyList<DatabaseProvider> _databaseProviders;
   private readonly IReadOnlyList<AresReleaseLayout> _releaseLayouts;
 
-  public ConfigurationEditorViewModel(IAppConfigurationService configurationService, IAppSettingsUpdater appSettingsUpdater)
+  public ConfigurationEditorViewModel(IAppConfigurationService configurationService, 
+    IAppSettingsUpdater appSettingsUpdater,
+    IAresUpdater aresUpdater,
+    IAresBinaryManager aresBinaryManager)
   {
     _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
     _appSettingsUpdater = appSettingsUpdater;
+    _aresUpdater = aresUpdater;
+    _aresBinaryManager = aresBinaryManager;
     _databaseProviders = Enum.GetValues<DatabaseProvider>();
     _releaseLayouts = Enum.GetValues<AresReleaseLayout>();
 
@@ -39,6 +48,13 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
     EditableAresServiceProcessName = string.Empty;
     EditableAresUiProcessName = string.Empty;
     EditableInstalledAresLayout = AresReleaseLayout.SplitUiAndService;
+    
+    var canInstall = this.WhenAnyValue(
+      x => x.SelectedRelease,
+      x => x.UpdateInProgress,
+      (selected, inProgress) => selected != null && !selected.IsInstalled && !inProgress);
+    UpdateAresCommand = ReactiveCommand.CreateFromTask(UpdateAres, canInstall);
+    
     LoadEditableConfiguration();
 
     AddRepositoryCommand = ReactiveCommand.Create(AddRepository);
@@ -49,11 +65,29 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
   }
 
   public event EventHandler? ConfigurationSaved;
+  public Interaction<UpdateConfirmationRequest, UpdateConfirmationResponse> UpdateConfirmationDialog { get; } = new();
 
   public IReadOnlyList<DatabaseProvider> DatabaseProviders => _databaseProviders;
   public IReadOnlyList<AresReleaseLayout> ReleaseLayouts => _releaseLayouts;
 
   public ObservableCollection<AresSourceEditorViewModel> AvailableRepositories { get; }
+
+  [Reactive]
+  public partial AresRelease[]? AvailableReleases { get; private set; }
+
+  [Reactive]
+  public partial AresRelease? SelectedRelease { get; set; }
+
+  [Reactive]
+  public partial string? InstalledAresVersion { get; private set; }
+
+  public ReactiveCommand<Unit, Unit> UpdateAresCommand { get; }
+
+  [Reactive]
+  public partial bool UpdateInProgress { get; private set; }
+
+  [Reactive]
+  public partial string? UpdateError { get; private set; }
 
   [Reactive]
   public partial AresSourceEditorViewModel? SelectedAvailableRepository { get; set; }
@@ -99,6 +133,9 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
 
   [Reactive]
   public partial AresReleaseLayout EditableInstalledAresLayout { get; set; }
+
+  [Reactive]
+  public partial bool EditableIncludeBeta { get; set; }
 
   [Reactive]
   public partial bool ShowAdvancedOptions { get; set; }
@@ -165,6 +202,7 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
       configuration.AresServiceProcessName = EditableAresServiceProcessName;
       configuration.AresUiProcessName = EditableAresUiProcessName;
       configuration.InstalledAresLayout = EditableInstalledAresLayout;
+      configuration.IncludeBeta = EditableIncludeBeta;
 
       var validRepositories = AvailableRepositories
         .Where(IsValidRepository)
@@ -213,6 +251,7 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
     EditableAresServiceProcessName = current.AresServiceProcessName;
     EditableAresUiProcessName = current.AresUiProcessName;
     EditableInstalledAresLayout = current.InstalledAresLayout;
+    EditableIncludeBeta = current.IncludeBeta;
 
     AvailableRepositories.Clear();
     foreach(var repo in current.AvailableAresRepos)
@@ -225,6 +264,86 @@ public partial class ConfigurationEditorViewModel : ViewModelBase
       string.Equals(repo.Owner, current.CurrentAresRepo.Owner, StringComparison.OrdinalIgnoreCase) &&
       string.Equals(repo.Repo, current.CurrentAresRepo.Repo, StringComparison.OrdinalIgnoreCase))
       ?? AvailableRepositories.FirstOrDefault();
+
+    _ = RefreshReleases();
+  }
+
+  private async Task RefreshReleases()
+  {
+    await _aresBinaryManager.Refresh();
+    var currentVersion = _aresBinaryManager.CurrentVersion;
+    InstalledAresVersion = currentVersion?.ToNormalizedString();
+
+    var releases = await _aresUpdater.GetAvailableVersions();
+    foreach(var release in releases)
+    {
+      release.IsInstalled = release.Version.Equals(currentVersion);
+    }
+
+    AvailableReleases = releases;
+    SelectedRelease = AvailableReleases.FirstOrDefault(r => r.IsInstalled) ?? AvailableReleases.FirstOrDefault();
+  }
+
+  private async Task UpdateAres()
+  {
+    if(SelectedRelease is null) return;
+
+    var currentVersion = _aresBinaryManager.CurrentVersion;
+    var targetVersion = SelectedRelease.Version;
+
+    if(RequiresUpdateConfirmation(currentVersion, targetVersion))
+    {
+      var isDowngrade = currentVersion is not null && targetVersion < currentVersion;
+      var hasSnapshot = isDowngrade && await _aresUpdater.HasSnapshot(targetVersion);
+
+      var response = await UpdateConfirmationDialog.Handle(new UpdateConfirmationRequest
+      {
+        CurrentVersion = currentVersion ?? targetVersion,
+        TargetVersion = targetVersion,
+        HasSnapshot = hasSnapshot
+      });
+
+      if(!response.ShouldProceed) return;
+
+      // Take snapshot of current version before doing anything
+      if(currentVersion is not null)
+      {
+        await _aresUpdater.CreateSnapshot(currentVersion);
+      }
+
+      if(response.DowngradeOption == DowngradeOption.RestoreSnapshot)
+      {
+        await _aresUpdater.RestoreSnapshot(targetVersion);
+      }
+      else if(response.DowngradeOption == DowngradeOption.Reset)
+      {
+        await _aresUpdater.ResetDatabase();
+      }
+    }
+
+    try
+    {
+      UpdateInProgress = true;
+      UpdateError = null;
+      await _aresUpdater.Update(targetVersion);
+    }
+    catch(Exception e)
+    {
+      UpdateError = e.Message;
+    }
+    finally
+    {
+      UpdateInProgress = false;
+      await RefreshReleases();
+    }
+  }
+
+  private static bool RequiresUpdateConfirmation(SemanticVersion? currentVersion, SemanticVersion? targetVersion)
+  {
+    if(currentVersion is null || targetVersion is null) return false;
+    if(targetVersion < currentVersion) return true;
+    if(targetVersion.Major > currentVersion.Major) return true;
+    return targetVersion.Major == currentVersion.Major && targetVersion.Minor > currentVersion.Minor;
   }
 
   private static bool IsValidRepository(AresSourceEditorViewModel repo)

--- a/ARESLauncher/ViewModels/MainViewModel.cs
+++ b/ARESLauncher/ViewModels/MainViewModel.cs
@@ -17,7 +17,6 @@ namespace ARESLauncher.ViewModels;
 
 public partial class MainViewModel : ViewModelBase
 {
-  private readonly IAppSettingsUpdater _appSettingsUpdater;
   private readonly IAresBinaryManager _aresBinaryManager;
   private readonly ObservableAsPropertyHelper<int> _aresComponentsRunning;
   private readonly IAresStarter _aresStarter;
@@ -29,7 +28,6 @@ public partial class MainViewModel : ViewModelBase
   private readonly ObservableAsPropertyHelper<object?> _auxButtonContent;
   private readonly ObservableAsPropertyHelper<IReactiveCommand?> _buttonCommand;
   private readonly ObservableAsPropertyHelper<string> _buttonText;
-  private readonly ICertificateManager _certificateManager;
   private readonly IConflictManager _conflictManager;
   private readonly ObservableAsPropertyHelper<UpdateStep> _currentUpdateStep;
   private readonly IDatabaseManager _databaseManager;
@@ -48,19 +46,17 @@ public partial class MainViewModel : ViewModelBase
     IAresBinaryManager aresBinaryManager,
     IAresStarter aresStarter,
     IAppSettingsUpdater appSettingsUpdater,
-    ICertificateManager certificateManager,
     IAresUpdater aresUpdater,
     ILauncherUpdater launcherUpdater,
     IDatabaseManager databaseManager,
     IBrowserOpener browserOpener,
     IConflictManager conflictManager)
   {
+    AvailableAresVersions = [];
     Overview = overview ?? throw new ArgumentNullException(nameof(overview));
     Editor = editor ?? throw new ArgumentNullException(nameof(editor));
     _aresBinaryManager = aresBinaryManager;
     _aresStarter = aresStarter;
-    _appSettingsUpdater = appSettingsUpdater;
-    _certificateManager = certificateManager;
     _aresUpdater = aresUpdater;
     _launcherUpdater = launcherUpdater;
     _databaseManager = databaseManager;
@@ -81,7 +77,7 @@ public partial class MainViewModel : ViewModelBase
     UpdateAresCommand = ReactiveCommand.CreateFromTask(UpdateAres);
     OpenBrowserCommand = ReactiveCommand.Create(browserOpener.Open);
     OpenLauncherReleasePageCommand = ReactiveCommand.CreateFromTask(CheckForUpdatedLauncher);
-    UpdateConfirmationDialog = new Interaction<UpdateConfirmationRequest, bool>();
+    UpdateConfirmationDialog = new Interaction<UpdateConfirmationRequest, UpdateConfirmationResponse>();
     ConflictDialog = new Interaction<Unit, Unit>();
     ResolveConflictsCommand = ReactiveCommand.CreateFromTask(async () =>
     {
@@ -103,15 +99,29 @@ public partial class MainViewModel : ViewModelBase
     _currentUpdateStep = _aresUpdater.CurrentUpdateStep.ToProperty(this, vm => vm.CurrentUpdateStep);
     _progress = _aresUpdater.UpdateProgress.ToProperty(this, vm => vm.Progress);
 
+    this.WhenAnyValue(x => x.Editor.UpdateInProgress)
+      .Skip(1)
+      .Subscribe((bool inProgress) => 
+      {
+        if(inProgress == false)
+          _ = this.CheckAresCondition();
+      });
+
     _aresComponentsRunning = _aresStarter
       .AresUiRunning
       .CombineLatest(_aresStarter.AresServiceRunning, (ui, service) => (ui ? 1 : 0) + (service ? 1 : 0))
       .ToProperty(this, vm => vm.AresComponentsRunning);
 
     _updateAvailable = this
-      .WhenAnyValue(x => x.AvailableVersions, x => x.AresComponentsRunning, x => x.CurrentUpdateStep, (av, runnin, updateStep) =>
+      .WhenAnyValue(x => x.AvailableAresUpdateVersion, x => x.AresComponentsRunning, x => x.CurrentUpdateStep, x => x.InstalledAresVersion, (av, runnin, updateStep, installedAresVersion) =>
       {
-        bool updateAvailable = av is not null && _aresBinaryManager.CurrentVersion is not null && !_aresBinaryManager.CurrentVersion.IsGreatest(av);
+        if(string.IsNullOrEmpty(av) || _aresBinaryManager.CurrentVersion is null)
+          return false;
+
+        if(!SemanticVersion.TryParse(av, out var latest))
+          return false;
+
+        bool updateAvailable = latest > _aresBinaryManager.CurrentVersion;
         return updateAvailable && runnin == 0 && updateStep == UpdateStep.Idle;
       })
       .ToProperty(this, vm => vm.UpdateAvailable);
@@ -132,9 +142,9 @@ public partial class MainViewModel : ViewModelBase
       vm => vm.AresPresent,
       vm => vm.DatabaseStatus,
       vm => vm.CurrentUpdateStep,
-      (isRunning, isPresent, dbStatus, updootStep) =>
+      (isRunning, isPresent, dbStatus, updateStep) =>
       {
-        if(updootStep != UpdateStep.Idle)
+        if(updateStep != UpdateStep.Idle)
         {
           return AresState.Updating;
         }
@@ -144,54 +154,51 @@ public partial class MainViewModel : ViewModelBase
         var partiallyRunning = layout == AresReleaseLayout.SplitUiAndService && isRunning == 1;
 
         if(partiallyRunning)
-        {
           return AresState.OneRunning;
-        }
+        
         if(fullyRunning)
-        {
           return AresState.BothRunning;
-        }
 
         if(!isPresent)
-        {
           return AresState.NeedsInstall;
-        }
 
         if(dbStatus != DatabaseStatus.UpToDate)
-        {
           return AresState.NeedsDbUpdate;
-        }
 
         return AresState.Ready;
       }).ToProperty(this, vm => vm.AresState);
 
 
     _buttonText = this
-      .WhenAnyValue(vm => vm.AresState)
-      .Select(s => s switch
+      .WhenAnyValue(vm => vm.AresState, (s) => 
       {
-        AresState.Unknown => ":)",
-        AresState.OneRunning => "Start",
-        AresState.BothRunning => "Stop",
-        AresState.Ready => "Start",
-        AresState.NeedsDbUpdate => "Update DB",
-        AresState.NeedsInstall => "Install",
-        AresState.Updating => "Updating...",
-        _ => throw new NotImplementedException()
+          return s switch
+          {
+            AresState.Unknown => ":)",
+            AresState.OneRunning => "Start",
+            AresState.BothRunning => "Stop",
+            AresState.Ready => "Start",
+            AresState.NeedsDbUpdate => "Update DB",
+            AresState.NeedsInstall => "Install",
+            AresState.Updating => "Updating...",
+            _ => throw new NotImplementedException()
+          };
       }).ToProperty(this, vm => vm.ButtonText);
 
     _buttonCommand = this
-      .WhenAnyValue(vm => vm.AresState)
-      .Select(s => s switch
+      .WhenAnyValue(vm => vm.AresState, (s) => 
       {
-        AresState.Unknown => null,
-        AresState.OneRunning => StartAresCommand,
-        AresState.BothRunning => StopAresCommand,
-        AresState.Ready => StartAresCommand,
-        AresState.NeedsDbUpdate => UpdateDatabaseCommand,
-        AresState.NeedsInstall => UpdateAresCommand,
-        AresState.Updating => null,
-        _ => throw new NotImplementedException()
+          return s switch
+          {
+            AresState.Unknown => null,
+            AresState.OneRunning => StartAresCommand,
+            AresState.BothRunning => StopAresCommand,
+            AresState.Ready => StartAresCommand,
+            AresState.NeedsDbUpdate => UpdateDatabaseCommand,
+            AresState.NeedsInstall => UpdateAresCommand,
+            AresState.Updating => null,
+            _ => throw new NotImplementedException()
+          };
       }).ToProperty(this, vm => vm.ButtonCommand);
 
     _auxButtonContent = this
@@ -237,14 +244,8 @@ public partial class MainViewModel : ViewModelBase
       }).ToProperty(this, vm => vm.AresStateDescription);
 
     _updateInProgress = this
-      .WhenAnyValue(vm => vm.CurrentUpdateStep)
-      .Select(s => s switch
-      {
-        UpdateStep.Idle => false,
-        UpdateStep.Downloading => true,
-        UpdateStep.Other => true,
-        _ => throw new NotImplementedException()
-      }).ToProperty(this, vm => vm.UpdateInProgress);
+      .WhenAnyValue(vm => vm.InstalledAresVersion)
+      .Select(IsLatestAresVersion).ToProperty(this, vm => vm.UpdateInProgress);
 
     _showProgressBar = this
       .WhenAnyValue(vm => vm.CurrentUpdateStep)
@@ -264,6 +265,9 @@ public partial class MainViewModel : ViewModelBase
     RefreshCommand.Execute();
   }
 
+  private bool IsLatestAresVersion(string version)
+    => AvailableAresVersions.FirstOrDefault()?.Version.ToNormalizedString() == InstalledAresVersion;
+  
   [Reactive]
   public partial bool AresConditionChecked { get; private set; }
 
@@ -320,21 +324,20 @@ public partial class MainViewModel : ViewModelBase
 
   public bool UpdateInProgress => _updateInProgress.Value;
 
-  public bool UpdateAvailable => _updateAvailable.Value;
+  public bool UpdateAvailable => _updateAvailable.Value; 
 
   public bool LauncherUpdateAvailable => _launcherUpdateAvailable.Value;
+
+  public AresRelease[] AvailableAresVersions { get; set; }
 
   private async Task UpdateAvailableVersions()
   {
     await _aresBinaryManager.Refresh();
     InstalledAresVersion = _aresBinaryManager.CurrentVersion?.ToNormalizedString() ?? string.Empty;
-    AvailableVersions = await _aresUpdater.GetAvailableVersions();
-    AvailableAresUpdateVersion = AvailableVersions?.OrderDescending().FirstOrDefault()?.ToNormalizedString() ?? string.Empty;
+    AvailableAresVersions = await _aresUpdater.GetAvailableVersions();
+    AvailableAresUpdateVersion = AvailableAresVersions?.FirstOrDefault()?.Version.ToNormalizedString() ?? string.Empty;
     AvailableLauncherVersions = await _launcherUpdater.GetAvailableVersions();
   }
-
-  [Reactive]
-  public partial SemanticVersion[]? AvailableVersions { get; private set; }
 
   [Reactive]
   public partial SemanticVersion[]? AvailableLauncherVersions { get; private set; }
@@ -358,7 +361,7 @@ public partial class MainViewModel : ViewModelBase
   public ReactiveCommand<Unit, Unit> CheckForUpdate { get; }
 
   public Interaction<Unit, Unit> ConflictDialog { get; }
-  public Interaction<UpdateConfirmationRequest, bool> UpdateConfirmationDialog { get; }
+  public Interaction<UpdateConfirmationRequest, UpdateConfirmationResponse> UpdateConfirmationDialog { get; }
   public bool ShowProgressBar => _showProgressBar.Value;
 
   public ConflictResolutionDialogViewModel GetConflictResolutionDialogViewModel()
@@ -373,49 +376,73 @@ public partial class MainViewModel : ViewModelBase
     await _aresBinaryManager.Refresh();
     InstalledAresVersion = _aresBinaryManager.CurrentVersion?.ToNormalizedString() ?? string.Empty;
     AresPresent = _aresBinaryManager.CurrentVersion is not null;
+
+    AvailableAresVersions = await _aresUpdater.GetAvailableVersions();
+    AvailableAresUpdateVersion = AvailableAresVersions?.FirstOrDefault()?.Version.ToNormalizedString() ?? string.Empty;
+    AvailableLauncherVersions = await _launcherUpdater.GetAvailableVersions();
+
     if(!AresPresent)
     {
       AresConditionChecked = true;
       return;
     }
 
-    AvailableVersions = await _aresUpdater.GetAvailableVersions();
-    AvailableAresUpdateVersion = AvailableVersions?.OrderDescending().FirstOrDefault()?.ToNormalizedString() ?? string.Empty;
-    AvailableLauncherVersions = await _launcherUpdater.GetAvailableVersions();
-
     await _databaseManager.Refresh();
     DatabaseStatus = _databaseManager.DatabaseStatus;
     if(DatabaseStatus != DatabaseStatus.UpToDate)
     {
       AresConditionChecked = true;
+      this.RaisePropertyChanged(nameof(UpdateAvailable));
       return;
     }
 
     AresConditionChecked = true;
+    this.RaisePropertyChanged(nameof(UpdateAvailable));
   }
 
   private async Task UpdateAres()
   {
     var currentVersion = _aresBinaryManager.CurrentVersion;
-    var targetVersion = AvailableVersions?.OrderDescending().FirstOrDefault();
+    AvailableAresVersions = await _aresUpdater.GetAvailableVersions();
+    var latest = AvailableAresVersions.FirstOrDefault();
+    
+    if(latest is null) 
+      return;
+    
+    var targetVersion = latest.Version;
+
     if(RequiresUpdateConfirmation(currentVersion, targetVersion))
     {
-      var shouldProceed = await UpdateConfirmationDialog.Handle(new UpdateConfirmationRequest
+      var isDowngrade = currentVersion is not null && targetVersion < currentVersion;
+      var hasSnapshot = isDowngrade && await _aresUpdater.HasSnapshot(targetVersion);
+
+      var response = await UpdateConfirmationDialog.Handle(new UpdateConfirmationRequest
       {
-        CurrentVersion = currentVersion!,
-        TargetVersion = targetVersion!
+        CurrentVersion = currentVersion ?? targetVersion,
+        TargetVersion = targetVersion,
+        HasSnapshot = hasSnapshot
       });
 
-      if(!shouldProceed)
-      {
+      if(!response.ShouldProceed)
         return;
-      }
+
+      // Take snapshot of current version before doing anything
+      if(currentVersion is not null)
+        await _aresUpdater.CreateSnapshot(currentVersion);
+
+      if(response.DowngradeOption == DowngradeOption.RestoreSnapshot)
+        await _aresUpdater.RestoreSnapshot(targetVersion);
+
+      else if(response.DowngradeOption == DowngradeOption.Reset)
+        await _aresUpdater.ResetDatabase();
+
+      await _aresBinaryManager.Refresh();
     }
 
     try
     {
       Error = "";
-      await _aresUpdater.UpdateLatest();
+      await _aresUpdater.Update(targetVersion);
     }
     catch(Exception e)
     {
@@ -441,14 +468,10 @@ public partial class MainViewModel : ViewModelBase
       }
 
       if(Application.Current is App app)
-      {
         app.BeginShutdown();
-      }
 
       if(Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
-      {
         desktopLifetime.Shutdown();
-      }
     }
 
     catch(Exception e)
@@ -482,12 +505,17 @@ public partial class MainViewModel : ViewModelBase
   }
   
   // Check if we should ask for confirmation. We should ask if there's a major/minor update
-  // Let's ignore patches as those should not break things... should
+  // Or if it's a downgrade
   private static bool RequiresUpdateConfirmation(SemanticVersion? currentVersion, SemanticVersion? targetVersion)
   {
     if(currentVersion is null || targetVersion is null)
     {
       return false;
+    }
+
+    if(targetVersion < currentVersion)
+    {
+      return true;
     }
 
     if(targetVersion.Major > currentVersion.Major)

--- a/ARESLauncher/ViewModels/UpdateConfirmationDialogViewModel.cs
+++ b/ARESLauncher/ViewModels/UpdateConfirmationDialogViewModel.cs
@@ -11,22 +11,34 @@ public class UpdateConfirmationDialogViewModel : ReactiveObject
     CurrentVersion = request.CurrentVersion.ToNormalizedString();
     TargetVersion = request.TargetVersion.ToNormalizedString();
 
-    MajorUpdate = request.TargetVersion.Major > request.CurrentVersion.Major;
+    MajorUpdate = request.TargetVersion > request.CurrentVersion && request.TargetVersion.Major > request.CurrentVersion.Major;
+    IsDowngrade = request.TargetVersion < request.CurrentVersion;
+    HasSnapshot = request.HasSnapshot;
     
-    ProceedCommand = ReactiveCommand.Create(() => Unit.Default);
-    CancelCommand = ReactiveCommand.Create(() => Unit.Default);
+    ProceedCommand = ReactiveCommand.Create(() => UpdateConfirmationResponse.Proceed());
+    CancelCommand = ReactiveCommand.Create(() => UpdateConfirmationResponse.Cancel);
+    RestoreSnapshotCommand = ReactiveCommand.Create(() => UpdateConfirmationResponse.Proceed(DowngradeOption.RestoreSnapshot));
+    ResetCommand = ReactiveCommand.Create(() => UpdateConfirmationResponse.Proceed(DowngradeOption.Reset));
   }
 
   public string CurrentVersion { get; }
   public string TargetVersion { get; }
   
   public bool MajorUpdate { get; }
+  public bool IsDowngrade { get; }
+  public bool HasSnapshot { get; }
 
   public string Message =>
-    MajorUpdate 
-      ? $"This will update ARES from {CurrentVersion} to {TargetVersion}.\nThis is a major update and we recommend backing up your database as there is potential of data loss."
-      : $"This will update ARES from {CurrentVersion} to {TargetVersion}.\nWhile this is a minor update, we would still recommend backing up your database just to be safe.";
+    IsDowngrade
+      ? HasSnapshot
+        ? $"You are downgrading ARES from {CurrentVersion} to {TargetVersion}.\nA database snapshot for version {TargetVersion} was found. Would you like to restore it?"
+        : $"You are downgrading ARES from {CurrentVersion} to {TargetVersion}.\nNo database snapshot for version {TargetVersion} was found. Your database will be reset to avoid compatibility issues."
+      : MajorUpdate 
+        ? $"This will update ARES from {CurrentVersion} to {TargetVersion}.\nThis is a major update and we recommend backing up your database as there is potential of data loss."
+        : $"This will update ARES from {CurrentVersion} to {TargetVersion}.\nWhile this is a minor update, we would still recommend backing up your database just to be safe.";
 
-  public ReactiveCommand<Unit, Unit> ProceedCommand { get; }
-  public ReactiveCommand<Unit, Unit> CancelCommand { get; }
+  public ReactiveCommand<Unit, UpdateConfirmationResponse> ProceedCommand { get; }
+  public ReactiveCommand<Unit, UpdateConfirmationResponse> CancelCommand { get; }
+  public ReactiveCommand<Unit, UpdateConfirmationResponse> RestoreSnapshotCommand { get; }
+  public ReactiveCommand<Unit, UpdateConfirmationResponse> ResetCommand { get; }
 }

--- a/ARESLauncher/Views/ConfigurationEditorView.axaml
+++ b/ARESLauncher/Views/ConfigurationEditorView.axaml
@@ -3,12 +3,62 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:ARESLauncher.ViewModels"
+             xmlns:models="clr-namespace:ARESLauncher.Models"
+             xmlns:ic="using:FluentIcons.Avalonia"
              mc:Ignorable="d"
              x:Class="ARESLauncher.Views.ConfigurationEditorView"
              x:DataType="vm:ConfigurationEditorViewModel">
     <ScrollViewer>
         <StackPanel Margin="16"
                     Spacing="12">
+
+            <!-- ARES Version Selection -->
+            <Border Padding="12" CornerRadius="8" Background="{DynamicResource SystemAccentColorLight}" Margin="0,0,0,12">
+                <StackPanel Spacing="8">
+                    <TextBlock Text="ARES Version Management" FontWeight="SemiBold" FontSize="14"/>
+                    <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto">
+                        <StackPanel Grid.Row="0" Grid.Column="0" Spacing="4">
+                             <TextBlock Text="Select Release:" FontSize="12"/>
+                             <ComboBox ItemsSource="{Binding AvailableReleases}"
+                                      SelectedItem="{Binding SelectedRelease}"
+                                      HorizontalAlignment="Stretch">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate x:DataType="models:AresRelease">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <TextBlock Text="{Binding Version}" />
+                                            <Border Background="#FF8C00" CornerRadius="4" Padding="4,0" IsVisible="{Binding IsBeta}">
+                                                <TextBlock Text="BETA" FontSize="10" Foreground="White" FontWeight="Bold" VerticalAlignment="Center"/>
+                                            </Border>
+                                            <TextBlock Text="(Installed)" IsVisible="{Binding IsInstalled}" FontStyle="Italic" Opacity="0.7"/>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+                        
+                        <Button Grid.Row="0" Grid.Column="1" 
+                                Command="{Binding UpdateAresCommand}"
+                                IsEnabled="{Binding !UpdateInProgress}"
+                                VerticalAlignment="Bottom"
+                                Margin="12,0,0,0"
+                                Padding="16,8">
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <ic:FluentIcon Icon="ArrowDownload" />
+                                <TextBlock Text="Install" FontWeight="SemiBold"/>
+                            </StackPanel>
+                        </Button>
+                        
+                        <ProgressBar Grid.Row="1" Grid.ColumnSpan="2" 
+                                     IsIndeterminate="True" 
+                                     IsVisible="{Binding UpdateInProgress}"
+                                     Height="4" Margin="0,8,0,0"/>
+                    </Grid>
+                    
+                    <TextBlock Text="{Binding UpdateError}" Foreground="Red" FontSize="12" 
+                               IsVisible="{Binding UpdateError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                </StackPanel>
+            </Border>
+
             <Grid ColumnDefinitions="Auto,*"
                   RowDefinitions="Auto,Auto,Auto">
                 <TextBlock Grid.Row="0"
@@ -41,105 +91,115 @@
             <StackPanel Spacing="12"
                         IsVisible="{Binding ShowAdvancedOptions}">
                 <Grid ColumnDefinitions="Auto,*"
-                      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
                     <TextBlock Grid.Row="0"
                                Grid.Column="0"
                                Margin="0,0,0,8"
                                VerticalAlignment="Center"
-                               Text="SQLite database path:" />
-                    <TextBox Grid.Row="0"
-                             Grid.Column="1"
-                             Margin="12,0,0,8"
-                             Text="{Binding EditableSqliteDatabasePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                               Text="Include beta releases:" />
+                    <ToggleSwitch Grid.Row="0"
+                                  Grid.Column="1"
+                                  Margin="12,0,0,8"
+                                  IsChecked="{Binding EditableIncludeBeta, Mode=TwoWay}" />
 
                     <TextBlock Grid.Row="1"
                                Grid.Column="0"
                                Margin="0,0,0,8"
                                VerticalAlignment="Center"
-                               Text="Database provider:" />
-                    <ComboBox Grid.Row="1"
-                              Grid.Column="1"
-                              Margin="12,0,0,8"
-                              ItemsSource="{Binding DatabaseProviders}"
-                              SelectedItem="{Binding EditableDatabaseProvider, Mode=TwoWay}" />
+                               Text="SQLite database path:" />
+                    <TextBox Grid.Row="1"
+                             Grid.Column="1"
+                             Margin="12,0,0,8"
+                             Text="{Binding EditableSqliteDatabasePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                     <TextBlock Grid.Row="2"
                                Grid.Column="0"
                                Margin="0,0,0,8"
                                VerticalAlignment="Center"
-                               Text="SQL Server connection string:" />
-                    <TextBox Grid.Row="2"
-                             Grid.Column="1"
-                             Margin="12,0,0,8"
-                             Text="{Binding EditableSqlServerConnectionString, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                               Text="Database provider:" />
+                    <ComboBox Grid.Row="2"
+                              Grid.Column="1"
+                              Margin="12,0,0,8"
+                              ItemsSource="{Binding DatabaseProviders}"
+                              SelectedItem="{Binding EditableDatabaseProvider, Mode=TwoWay}" />
 
                     <TextBlock Grid.Row="3"
                                Grid.Column="0"
                                Margin="0,0,0,8"
                                VerticalAlignment="Center"
-                               Text="Postgres connection string:" />
+                               Text="SQL Server connection string:" />
                     <TextBox Grid.Row="3"
                              Grid.Column="1"
                              Margin="12,0,0,8"
-                             Text="{Binding EditablePostgresConnectionString, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                             Text="{Binding EditableSqlServerConnectionString, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                     <TextBlock Grid.Row="4"
                                Grid.Column="0"
                                Margin="0,0,0,8"
                                VerticalAlignment="Center"
-                               Text="Service endpoint:" />
+                               Text="Postgres connection string:" />
                     <TextBox Grid.Row="4"
                              Grid.Column="1"
                              Margin="12,0,0,8"
-                             Text="{Binding EditableServiceEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                             Text="{Binding EditablePostgresConnectionString, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                     <TextBlock Grid.Row="5"
                                Grid.Column="0"
                                Margin="0,0,0,8"
                                VerticalAlignment="Center"
-                               Text="UI endpoint:" />
+                               Text="Service endpoint:" />
                     <TextBox Grid.Row="5"
                              Grid.Column="1"
                              Margin="12,0,0,8"
-                             Text="{Binding EditableUiEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                             Text="{Binding EditableServiceEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                     <TextBlock Grid.Row="6"
                                Grid.Column="0"
                                Margin="0,0,0,8"
                                VerticalAlignment="Center"
-                               Text="ARES data path:" />
+                               Text="UI endpoint:" />
                     <TextBox Grid.Row="6"
                              Grid.Column="1"
                              Margin="12,0,0,8"
-                             Text="{Binding EditableAresDataPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                             Text="{Binding EditableUiEndpoint, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                     <TextBlock Grid.Row="7"
                                Grid.Column="0"
                                Margin="0,0,0,8"
                                VerticalAlignment="Center"
-                               Text="ARES service process:" />
+                               Text="ARES data path:" />
                     <TextBox Grid.Row="7"
                              Grid.Column="1"
                              Margin="12,0,0,8"
-                             Text="{Binding EditableAresServiceProcessName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                             Text="{Binding EditableAresDataPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                     <TextBlock Grid.Row="8"
                                Grid.Column="0"
                                Margin="0,0,0,8"
                                VerticalAlignment="Center"
-                               Text="Installed ARES layout:" />
-                    <ComboBox Grid.Row="8"
-                              Grid.Column="1"
-                              Margin="12,0,0,8"
-                              ItemsSource="{Binding ReleaseLayouts}"
-                              SelectedItem="{Binding EditableInstalledAresLayout, Mode=TwoWay}" />
+                               Text="ARES service process:" />
+                    <TextBox Grid.Row="8"
+                             Grid.Column="1"
+                             Margin="12,0,0,8"
+                             Text="{Binding EditableAresServiceProcessName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                     <TextBlock Grid.Row="9"
                                Grid.Column="0"
                                Margin="0,0,0,8"
                                VerticalAlignment="Center"
+                               Text="Installed ARES layout:" />
+                    <ComboBox Grid.Row="9"
+                              Grid.Column="1"
+                              Margin="12,0,0,8"
+                              ItemsSource="{Binding ReleaseLayouts}"
+                              SelectedItem="{Binding EditableInstalledAresLayout, Mode=TwoWay}" />
+
+                    <TextBlock Grid.Row="10"
+                               Grid.Column="0"
+                               Margin="0,0,0,8"
+                               VerticalAlignment="Center"
                                Text="ARES UI process:" />
-                    <TextBox Grid.Row="9"
+                    <TextBox Grid.Row="10"
                              Grid.Column="1"
                              Margin="12,0,0,0"
                              Text="{Binding EditableAresUiProcessName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/ARESLauncher/Views/ConfigurationEditorView.axaml.cs
+++ b/ARESLauncher/Views/ConfigurationEditorView.axaml.cs
@@ -1,11 +1,48 @@
+using ARESLauncher.Models;
+using ARESLauncher.ViewModels;
 using Avalonia.Controls;
+using ReactiveUI;
+using System;
+using System.Threading.Tasks;
 
 namespace ARESLauncher.Views;
 
-public partial class ConfigurationEditorView : UserControl
+public partial class ConfigurationEditorView : UserControl, IActivatableView
 {
   public ConfigurationEditorView()
   {
     InitializeComponent();
+    this.WhenActivated(d =>
+    {
+      if(DataContext is ConfigurationEditorViewModel viewModel)
+        d(viewModel.UpdateConfirmationDialog.RegisterHandler(DoShowUpdateConfirmationDialog));
+      
+    });
+  }
+
+  private async Task DoShowUpdateConfirmationDialog(InteractionContext<UpdateConfirmationRequest, UpdateConfirmationResponse> context)
+  {
+    var dialogVm = new UpdateConfirmationDialogViewModel(context.Input);
+    var dialog = new UpdateConfirmationDialog
+    {
+      DataContext = dialogVm
+    };
+
+    var closeAndSet = new Action<UpdateConfirmationResponse>(dialog.Close);
+
+    dialogVm.ProceedCommand.Subscribe(closeAndSet);
+    dialogVm.CancelCommand.Subscribe(closeAndSet);
+    dialogVm.RestoreSnapshotCommand.Subscribe(closeAndSet);
+    dialogVm.ResetCommand.Subscribe(closeAndSet);
+
+    var topLevel = TopLevel.GetTopLevel(this);
+    if(topLevel is Window window)
+    {
+      var result = await dialog.ShowDialog<UpdateConfirmationResponse>(window);
+      context.SetOutput(result ?? UpdateConfirmationResponse.Cancel);
+    }
+
+    else
+      context.SetOutput(UpdateConfirmationResponse.Proceed());
   }
 }

--- a/ARESLauncher/Views/MainView.axaml
+++ b/ARESLauncher/Views/MainView.axaml
@@ -6,6 +6,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:ARESLauncher.ViewModels"
+             xmlns:models="clr-namespace:ARESLauncher.Models"
              xmlns:views="clr-namespace:ARESLauncher.Views"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="ARESLauncher.Views.MainView"
@@ -36,17 +37,17 @@
     <Grid>
         <TabControl>
             <TabItem Header="Overview">
-                <Grid RowDefinitions="100,*,Auto">
+                <Grid RowDefinitions="50,*,Auto">
                     <!-- Top Logo -->
                     <areslauncher:AresLogo Grid.Row="0" Grid.RowSpan="2" IsHitTestVisible="False" Height="180"
                                            HorizontalAlignment="Right" VerticalAlignment="Top" Margin="5,-75,5,5" />
 
                     <!-- Main Content -->
-                    <Grid Grid.Row="1" RowDefinitions="*,Auto,Auto,Auto,Auto" RowSpacing="5" VerticalAlignment="Top"
+                    <Grid Grid.Row="1" RowDefinitions="Auto,Auto,Auto,Auto,Auto" RowSpacing="10" VerticalAlignment="Top"
                           HorizontalAlignment="Center" MaxWidth="400">
 
                         <!-- Primary and auxiliary buttons -->
-                        <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Spacing="10">
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center" Spacing="10" Margin="0,0,0,5">
                             <Button Classes="AresButton" x:Name="PrimaryButton"
                                     IsVisible="{Binding LauncherReady}"
                                     Width="180" Height="80"
@@ -75,8 +76,7 @@
                             Text="{Binding AresStateDescription}"
                             IsVisible="{Binding !UpdateInProgress}"
                             HorizontalAlignment="Center"
-                            FontSize="16"
-                            Margin="0,15,0,0" />
+                            FontSize="16" />
                             <TextBlock
                             Text="{Binding InstalledAresVersion, StringFormat='ARES version: {0}'}"
                             IsVisible="{Binding InstalledAresVersion, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
@@ -95,7 +95,7 @@
                             <StackPanel Spacing="8">
                                 <Button Command="{Binding UpdateAresCommand}" HorizontalAlignment="Stretch" Classes="info">
                                     <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
-                                        <TextBlock Text="⇧" />
+                                        <ic:FluentIcon Icon="ArrowCircleUp" />
                                         <TextBlock Text="Update" FontWeight="SemiBold" />
                                     </StackPanel>
                                 </Button>

--- a/ARESLauncher/Views/MainWindow.axaml.cs
+++ b/ARESLauncher/Views/MainWindow.axaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reactive;
 using System.Reactive.Linq;
+using ARESLauncher.Models;
 using ARESLauncher.ViewModels;
 using Avalonia;
 using Avalonia.Controls;
@@ -47,11 +48,15 @@ public partial class MainWindow : Window
         DataContext = dialogVm
       };
 
-      dialogVm.ProceedCommand.Subscribe(_ => dialog.Close(true));
-      dialogVm.CancelCommand.Subscribe(_ => dialog.Close(false));
+      var closeAndSet = new Action<UpdateConfirmationResponse>(res => dialog.Close(res));
 
-      var result = await dialog.ShowDialog<bool>(this);
-      interaction.SetOutput(result);
+      dialogVm.ProceedCommand.Subscribe(closeAndSet);
+      dialogVm.CancelCommand.Subscribe(closeAndSet);
+      dialogVm.RestoreSnapshotCommand.Subscribe(closeAndSet);
+      dialogVm.ResetCommand.Subscribe(closeAndSet);
+
+      var result = await dialog.ShowDialog<UpdateConfirmationResponse>(this);
+      interaction.SetOutput(result ?? UpdateConfirmationResponse.Cancel);
     });
   }
 

--- a/ARESLauncher/Views/UpdateConfirmationDialog.axaml
+++ b/ARESLauncher/Views/UpdateConfirmationDialog.axaml
@@ -22,17 +22,37 @@
                        TextWrapping="Wrap"
                        TextAlignment="Center" />
             <TextBlock Text="Do you want to continue with this update?"
-                       TextAlignment="Center" />
+                       TextAlignment="Center"
+                       IsVisible="{Binding !IsDowngrade}"/>
             <StackPanel Orientation="Horizontal"
                         HorizontalAlignment="Center"
                         Spacing="12"
-                        Margin="0,8,0,0">
+                        Margin="0,8,0,0"
+                        IsVisible="{Binding !IsDowngrade}">
                 <Button Content="Cancel"
                         MinWidth="120"
                         Command="{Binding CancelCommand}" />
                 <Button Content="Proceed"
                         MinWidth="120"
                         Command="{Binding ProceedCommand}" />
+            </StackPanel>
+            <StackPanel Orientation="Vertical"
+                        HorizontalAlignment="Center"
+                        Spacing="12"
+                        Margin="0,8,0,0"
+                        IsVisible="{Binding IsDowngrade}">
+                <StackPanel Orientation="Horizontal" Spacing="12">
+                    <Button Content="Restore Snapshot"
+                            MinWidth="120"
+                            Command="{Binding RestoreSnapshotCommand}"
+                            IsVisible="{Binding HasSnapshot}" />
+                    <Button Content="Reset Database"
+                            MinWidth="120"
+                            Command="{Binding ResetCommand}" />
+                </StackPanel>
+                <Button Content="Cancel"
+                        HorizontalAlignment="Stretch"
+                        Command="{Binding CancelCommand}" />
             </StackPanel>
         </StackPanel>
     </Border>


### PR DESCRIPTION
Updates that allow the launcher to create snapshots of databases for their ARES install, enabling a user to rollback their ARES version in the scenario of a bad update and recover their database in the process. Also added support for selecting versions, allowing for beta testing to take place if the user is opted in.